### PR TITLE
Dev particle interface

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,2 +1,29 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.9.3"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/Project.toml
+++ b/Project.toml
@@ -3,5 +3,8 @@ uuid = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
 authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
 version = "0.1.0"
 
+[deps]
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+
 [compat]
 julia = "1.9"

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -1,11 +1,18 @@
 module QEDprocesses
 
-# Write your package code here.
+# Abstract particle interface
 export AbstractParticle
 export is_fermion, is_boson, is_particle, is_anti_particle
 export mass, charge
 
+# particle types
+export AbstractParticleType
+export FermionLike, Fermion, AntiFermion, MajoranaFermion
+export BosonLike, Boson, AntiBoson, MajoranaBoson
+export Electron, Positron, Photon
+
 using DocStringExtensions
 
 include("interfaces/particle_interface.jl")
+include("particle_types.jl")
 end

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -1,5 +1,11 @@
 module QEDprocesses
 
 # Write your package code here.
+export AbstractParticle
+export is_fermion, is_boson, is_particle, is_anti_particle
+export mass, charge
 
+using DocStringExtensions
+
+include("interfaces/particle_interface.jl")
 end

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -1,0 +1,91 @@
+###############
+# The paricle interface
+#
+# In this file, we define the interface of working with particles in a general
+# sense. 
+# 
+# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
+# ecosystem.
+#
+###############
+
+
+"""
+Abstract base type for every type which might be considered as a `particle` in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of functions implemented: static functions and property functions. 
+The static functions say something, what kind of particle it is (defaults are written in square brackets)
+
+```julia
+    is_fermion(::AbstractParticle)::Bool [= false]
+    is_boson(::AbstractParticle)::Bool [= false]
+    is_particle(::AbstractParticle)::Bool [= true]
+    is_anti_particle(::AbstractParticle)::Bool [= false]
+``` 
+If the output of those functions differ from the defaults for a subtype of `AbstractParticle`, these functions need to be overwritten.
+The second type of functions define a soft interface `AbstractParticle`:
+
+```julia
+    mass(::AbstractParticle)::Real
+    charge(::AbstractParticle)::Real
+```
+These functions need to be implemented in order to have the subtype of `AbstractParticle` work with the functionalities of `QEDprocesses.jl`.
+"""
+abstract type AbstractParticle end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered as a `fermion` in the sense of particle statistics, and `false` otherwise.
+
+The default implementation of `is_fermion` for every subtype of `AbstractParticle` will always return `false`.
+"""
+Base.@pure is_fermion(::AbstractParticle) = false
+
+"""
+    $(TYPEDSIGNATURES)
+
+Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered as a `boson` in the sense of particle statistics, and `false` otherwise.
+The default implementation of `is_boson` for every subtype of `AbstractParticle` will always return `false`.
+"""
+Base.@pure is_boson(::AbstractParticle) = false
+
+"""
+    $(TYPEDSIGNATURES)
+    
+Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered as a *particle* as distinct from anti-particles, and `false` otherwise.
+The default implementation of `is_particle` for every subtype of `AbstractParticle` will always return `true`.
+"""
+Base.@pure is_particle(::AbstractParticle) = true
+
+"""
+    $(TYPEDSIGNATURES)
+
+Interface function for particles. Return true if the passed subtype of `AbstractParticle` can be considered as a *anti particle* as distinct from their particle counterpart, and `false` otherwise.
+The default implementation of `is_anti_particle` for every subtype of `AbstractParticle` will always return `false`.
+"""
+Base.@pure is_anti_particle(::AbstractParticle) = false
+
+"""
+    $(TYPEDSIGNATURES)
+
+Interface function for particles. Return the rest mass of a particle (in units of the electron mass).
+
+This needs to be implemented for each concrete subtype of `AbstractParticle` and will throw an error otherwise.
+"""
+function mass(particle::AbstractParticle)::Real
+    return error(
+        "The function mass($(typeof(particle))) is not implemented. You need to implement it to use the particle interface.",
+    )
+end
+
+"""
+    $(TYPEDSIGNATURES)
+
+Interface function for particles. Return the electric charge of a particle (in units of the elementary electric charge).
+
+This needs to be implemented for each concrete subtype of `AbstractParticle` and will throw an error otherwise.
+"""
+function charge(::AbstractParticle)::Real
+    return error(
+        "The function mass($(typeof(particle))) is not implemented. You need to implement it to use the particle interface.",
+    )
+end

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -11,7 +11,7 @@
 
 
 """
-Abstract base type for every type which might be considered as a `particle` in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of functions implemented: static functions and property functions. 
+Abstract base type for every type which might be considered as a `particle` in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of interface functions implemented: static functions and property functions. 
 The static functions provide information on what kind of particle it is (defaults are written in square brackets)
 
 ```julia
@@ -21,13 +21,13 @@ The static functions provide information on what kind of particle it is (default
     is_anti_particle(::AbstractParticle)::Bool [= false]
 ``` 
 If the output of those functions differ from the defaults for a subtype of `AbstractParticle`, these functions need to be overwritten.
-The second type of functions define a soft interface `AbstractParticle`:
+The second type of functions define a hard interface for `AbstractParticle`:
 
 ```julia
     mass(::AbstractParticle)::Real
     charge(::AbstractParticle)::Real
 ```
-These functions need to be implemented in order to have the subtype of `AbstractParticle` work with the functionalities of `QEDprocesses.jl`.
+These functions must be implemented in order to have the subtype of `AbstractParticle` work with the functionalities of `QEDprocesses.jl`.
 """
 abstract type AbstractParticle end
 

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -11,7 +11,7 @@
 
 
 """
-Abstract base type for every type which might be considered as a `particle` in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of interface functions implemented: static functions and property functions. 
+Abstract base type for every type which might be considered a *particle* in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of interface functions implemented: static functions and property functions. 
 The static functions provide information on what kind of particle it is (defaults are written in square brackets)
 
 ```julia
@@ -34,7 +34,7 @@ abstract type AbstractParticle end
 """
     $(TYPEDSIGNATURES)
 
-Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered as a *fermion* in the sense of particle statistics, and `false` otherwise.
+Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered a *fermion* in the sense of particle statistics, and `false` otherwise.
 
 The default implementation of `is_fermion` for every subtype of `AbstractParticle` will always return `false`.
 """
@@ -43,7 +43,7 @@ Base.@pure is_fermion(::AbstractParticle) = false
 """
     $(TYPEDSIGNATURES)
 
-Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered as a *boson* in the sense of particle statistics, and `false` otherwise.
+Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered a *boson* in the sense of particle statistics, and `false` otherwise.
 The default implementation of `is_boson` for every subtype of `AbstractParticle` will always return `false`.
 """
 Base.@pure is_boson(::AbstractParticle) = false
@@ -51,7 +51,7 @@ Base.@pure is_boson(::AbstractParticle) = false
 """
     $(TYPEDSIGNATURES)
     
-Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered as a *particle* as distinct from anti-particles, and `false` otherwise.
+Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered a *particle* as distinct from anti-particles, and `false` otherwise.
 The default implementation of `is_particle` for every subtype of `AbstractParticle` will always return `true`.
 """
 Base.@pure is_particle(::AbstractParticle) = true
@@ -59,7 +59,7 @@ Base.@pure is_particle(::AbstractParticle) = true
 """
     $(TYPEDSIGNATURES)
 
-Interface function for particles. Return true if the passed subtype of `AbstractParticle` can be considered as a *anti particle* as distinct from their particle counterpart, and `false` otherwise.
+Interface function for particles. Return true if the passed subtype of `AbstractParticle` can be considered a *anti particle* as distinct from their particle counterpart, and `false` otherwise.
 The default implementation of `is_anti_particle` for every subtype of `AbstractParticle` will always return `false`.
 """
 Base.@pure is_anti_particle(::AbstractParticle) = false

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -59,7 +59,7 @@ Base.@pure is_particle(::AbstractParticle) = true
 """
     $(TYPEDSIGNATURES)
 
-Interface function for particles. Return true if the passed subtype of `AbstractParticle` can be considered a *anti particle* as distinct from their particle counterpart, and `false` otherwise.
+Interface function for particles. Return true if the passed subtype of `AbstractParticle` can be considered an *anti particle* as distinct from their particle counterpart, and `false` otherwise.
 The default implementation of `is_anti_particle` for every subtype of `AbstractParticle` will always return `false`.
 """
 Base.@pure is_anti_particle(::AbstractParticle) = false

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -12,7 +12,7 @@
 
 """
 Abstract base type for every type which might be considered as a `particle` in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of functions implemented: static functions and property functions. 
-The static functions say something, what kind of particle it is (defaults are written in square brackets)
+The static functions provide information on what kind of particle it is (defaults are written in square brackets)
 
 ```julia
     is_fermion(::AbstractParticle)::Bool [= false]

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -35,7 +35,6 @@ abstract type AbstractParticle end
     $(TYPEDSIGNATURES)
 
 Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered a *fermion* in the sense of particle statistics, and `false` otherwise.
-
 The default implementation of `is_fermion` for every subtype of `AbstractParticle` will always return `false`.
 """
 Base.@pure is_fermion(::AbstractParticle) = false

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -34,7 +34,7 @@ abstract type AbstractParticle end
 """
     $(TYPEDSIGNATURES)
 
-Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered as a `fermion` in the sense of particle statistics, and `false` otherwise.
+Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered as a *fermion* in the sense of particle statistics, and `false` otherwise.
 
 The default implementation of `is_fermion` for every subtype of `AbstractParticle` will always return `false`.
 """
@@ -43,7 +43,7 @@ Base.@pure is_fermion(::AbstractParticle) = false
 """
     $(TYPEDSIGNATURES)
 
-Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered as a `boson` in the sense of particle statistics, and `false` otherwise.
+Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered as a *boson* in the sense of particle statistics, and `false` otherwise.
 The default implementation of `is_boson` for every subtype of `AbstractParticle` will always return `false`.
 """
 Base.@pure is_boson(::AbstractParticle) = false

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -1,7 +1,7 @@
 ###############
 # The paricle interface
 #
-# In this file, we define the interface of working with particles in a general
+# In this file, we define the interface for working with particles in a general
 # sense. 
 # 
 # This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -37,7 +37,7 @@ abstract type AbstractParticle end
 Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered a *fermion* in the sense of particle statistics, and `false` otherwise.
 The default implementation of `is_fermion` for every subtype of `AbstractParticle` will always return `false`.
 """
-Base.@pure is_fermion(::AbstractParticle) = false
+is_fermion(::AbstractParticle) = false
 
 """
     $(TYPEDSIGNATURES)
@@ -45,7 +45,7 @@ Base.@pure is_fermion(::AbstractParticle) = false
 Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered a *boson* in the sense of particle statistics, and `false` otherwise.
 The default implementation of `is_boson` for every subtype of `AbstractParticle` will always return `false`.
 """
-Base.@pure is_boson(::AbstractParticle) = false
+is_boson(::AbstractParticle) = false
 
 """
     $(TYPEDSIGNATURES)
@@ -53,7 +53,7 @@ Base.@pure is_boson(::AbstractParticle) = false
 Interface function for particles. Return `true` if the passed subtype of `AbstractParticle` can be considered a *particle* as distinct from anti-particles, and `false` otherwise.
 The default implementation of `is_particle` for every subtype of `AbstractParticle` will always return `true`.
 """
-Base.@pure is_particle(::AbstractParticle) = true
+is_particle(::AbstractParticle) = true
 
 """
     $(TYPEDSIGNATURES)
@@ -61,7 +61,7 @@ Base.@pure is_particle(::AbstractParticle) = true
 Interface function for particles. Return true if the passed subtype of `AbstractParticle` can be considered an *anti particle* as distinct from their particle counterpart, and `false` otherwise.
 The default implementation of `is_anti_particle` for every subtype of `AbstractParticle` will always return `false`.
 """
-Base.@pure is_anti_particle(::AbstractParticle) = false
+is_anti_particle(::AbstractParticle) = false
 
 """
     $(TYPEDSIGNATURES)

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -85,6 +85,6 @@ This needs to be implemented for each concrete subtype of `AbstractParticle` and
 """
 function charge(::AbstractParticle)::Real
     return error(
-        "The function mass($(typeof(particle))) is not implemented. You need to implement it to use the particle interface.",
+        "The function charge($(typeof(particle))) is not implemented. You need to implement it to use the particle interface.",
     )
 end

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -93,7 +93,7 @@ Base.@pure is_anti_particle(::MajoranaFermion) = true
 Concrete type for *electrons* as a particle species. Mostly used for dispatch. 
 
 !!! note "particle interface"
-    Besides being a subtype of `Fermion`, `Electrons` have
+    Besides being a subtype of `Fermion`, objects of type `Electron` have
 
     ```julia
     mass(::Electron) = 1.0
@@ -108,7 +108,7 @@ charge(::Electron) = -1.0
 Concrete type for *positrons* as a particle species. Mostly used for dispatch. 
 
 !!! note "particle interface"
-    Besides being a subtype of `AntiFermion`, `Positron` have
+    Besides being a subtype of `AntiFermion`, objects of type `Positron` have
 
     ```julia
     mass(::Positron) = 1.0

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -1,13 +1,11 @@
 ###############
-# 
-# particles.jl
+# The particle types 
 #
 # In this file, we define the types of particles used in `QEDprocesses.jl` and
 # implement the abstact particle interface accordingly. 
 # 
 # This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
 # ecosystem.
-#
 ###############
 
 """

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -120,9 +120,6 @@ struct Positron <: AntiFermion end
 mass(::Positron) = 1.0
 charge(::Positron) = 1.0
 
-####
-# particle information carts - Bosons
-####
 """
 Abstract base types for particle species that act like bosons in the sense of particle statistics. 
     

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -154,7 +154,7 @@ Abstract base type for anti-bosons as distinct from its particle counterpart `Bo
     ```julia 
     is_boson(::AntiBoson) = true
     is_particle(::AntiBoson) = false
-    is_anti_particle(::AntiBoson) = false
+    is_anti_particle(::AntiBoson) = true
     ```
 
 """

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -178,8 +178,6 @@ abstract type MajoranaBoson <: BosonLike end
 Base.@pure is_particle(::MajoranaBoson) = true
 Base.@pure is_anti_particle(::MajoranaBoson) = true
 
-# TODO: is traits for massless and uncharged particles
-# 		This makes the function calls more specialized
 """
 Concrete type for the *photons* as a particle species. Mostly used for dispatch. 
 

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -72,7 +72,7 @@ Base.@pure is_particle(::AntiFermion) = false
 Base.@pure is_anti_particle(::AntiFermion) = true
 
 """
-Abstract base type for majorana-fermions, i.e. fermions which are their own anti-particles .
+Abstract base type for majorana-fermions, i.e. fermions which are their own anti-particles.
 
 !!! note "particle interface"
     All subtypes of `MajoranaFermion` have 

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -105,7 +105,7 @@ mass(::Electron) = 1.0
 charge(::Electron) = -1.0
 
 """
-Concrete type for the *positrons* as a particle species. Mostly used for dispatch. 
+Concrete type for *positrons* as a particle species. Mostly used for dispatch. 
 
 !!! note "particle interface"
     Besides being a subtype of `AntiFermion`, `Positron` have

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -153,7 +153,7 @@ Abstract base type for anti-bosons as distinct from its particle counterpart `Bo
     All subtypes of `AntiBoson` have
     ```julia 
     is_boson(::AntiBoson) = true
-    is_particle(::AntiBoson) = true
+    is_particle(::AntiBoson) = false
     is_anti_particle(::AntiBoson) = false
     ```
 

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -90,7 +90,7 @@ Base.@pure is_particle(::MajoranaFermion) = true
 Base.@pure is_anti_particle(::MajoranaFermion) = true
 
 """
-Concrete type for the *electrons* as a particle species. Mostly used for dispatch. 
+Concrete type for *electrons* as a particle species. Mostly used for dispatch. 
 
 !!! note "particle interface"
     Besides being a subtype of `Fermion`, `Electrons` have

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -1,0 +1,202 @@
+###############
+# 
+# particles.jl
+#
+# In this file, we define the types of particles used in `QEDprocesses.jl` and
+# implement the abstact particle interface accordingly. 
+# 
+# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
+# ecosystem.
+#
+###############
+
+"""
+    AbstractParticleType <: AbstractParticle
+
+This is the abstract base type for every species of particles. All functionalities defined on subtypes of `AbstractParticleType` should be static, i.e. known at compile time. 
+For adding runtime information, e.g. four-momenta or particle states, to a particle, consider implementing concrete subtype of `AbstractParticle` instead, which may has a type parameter `P<:AbstractParticleType`. See the concrete type `Particle{P,ST,MT}`
+
+Concrete built-in subtypes of `AbstractParticleType` are 
+
+```julia
+    Electron
+    Positron
+    Photon
+```
+
+"""
+abstract type AbstractParticleType <: AbstractParticle end
+
+"""
+Abstract base types for particle species that act like fermions in the sense of particle statistics. 
+    
+!!! note "particle interface"
+    Every concrete subtype of `FermionLike` has `is_fermion(::FermionLike) = true`.
+"""
+abstract type FermionLike <: AbstractParticleType end
+
+Base.@pure is_fermion(::FermionLike) = true
+
+"""
+Abstract base type for fermions as distinct from anti-fermions. 
+    
+!!! note "particle interface"
+    All subtypes of `Fermion` have
+    ```julia 
+    is_fermion(::Fermion) = true
+    is_particle(::Fermion) = true
+    is_anti_particle(::Fermion) = false
+    ```
+
+"""
+abstract type Fermion <: FermionLike end
+
+Base.@pure is_particle(::Fermion) = true
+
+Base.@pure is_anti_particle(::Fermion) = false
+
+"""
+Abstract base type for anti-fermions as distinct from its particle counterpart `Fermion`.
+
+!!! note "particle interface"
+    All subtypes of `AntiFermion` have 
+    ```julia 
+    is_fermion(::Fermion) = true
+    is_particle(::AntiFermion) = false
+    is_anti_particle(::AntiFermion) = true
+    ```
+    
+"""
+abstract type AntiFermion <: FermionLike end
+
+Base.@pure is_particle(::AntiFermion) = false
+
+Base.@pure is_anti_particle(::AntiFermion) = true
+
+"""
+Abstract base type for majorana-fermions, i.e. fermions which are their own anti-particles .
+
+!!! note "particle interface"
+    All subtypes of `MajoranaFermion` have 
+    ```julia 
+    is_fermion(::Fermion) = true
+    is_particle(::MajoranaFermion) = true
+    is_anti_particle(::MajoranaFermion) = true
+    ```
+    
+"""
+abstract type MajoranaFermion <: FermionLike end
+
+Base.@pure is_particle(::MajoranaFermion) = true
+
+Base.@pure is_anti_particle(::MajoranaFermion) = true
+
+"""
+Concrete type for the *electrons* as a particle species. Mostly used for dispatch. 
+
+!!! note "particle interface"
+    Besides being a subtype of `Fermion`, `Electrons` have
+
+    ```julia
+    mass(::Electron) = 1.0
+    charge(::Electron) = -1.0
+    ```
+"""
+struct Electron <: Fermion end
+mass(::Electron) = 1.0
+charge(::Electron) = -1.0
+
+"""
+Concrete type for the *positrons* as a particle species. Mostly used for dispatch. 
+
+!!! note "particle interface"
+    Besides being a subtype of `AntiFermion`, `Positron` have
+
+    ```julia
+    mass(::Positron) = 1.0
+    charge(::Positron) = 1.0
+    ```
+    
+"""
+struct Positron <: AntiFermion end
+mass(::Positron) = 1.0
+charge(::Positron) = 1.0
+
+####
+# particle information carts - Bosons
+####
+"""
+Abstract base types for particle species that act like bosons in the sense of particle statistics. 
+    
+!!! note "particle interface"
+    Every concrete subtype of `BosonLike` has `is_boson(::BosonLike) = true`.
+"""
+abstract type BosonLike <: AbstractParticleType end
+
+is_boson(::BosonLike) = true
+
+"""
+Abstract base type for bosons as distinct from its anti-particle counterpart `AntiBoson`. 
+    
+!!! note "particle interface"
+    All subtypes of `Boson` have
+    ```julia 
+    is_boson(::Boson) = true
+    is_particle(::Boson) = true
+    is_anti_particle(::Boson) = false
+    ```
+
+"""
+abstract type Boson <: BosonLike end
+Base.@pure is_particle(::Boson) = true
+Base.@pure is_anti_particle(::Boson) = false
+
+"""
+Abstract base type for anti-bosons as distinct from its particle counterpart `Bosons`. 
+    
+!!! note "particle interface"
+    All subtypes of `AntiBoson` have
+    ```julia 
+    is_boson(::AntiBoson) = true
+    is_particle(::AntiBoson) = true
+    is_anti_particle(::AntiBoson) = false
+    ```
+
+"""
+abstract type AntiBoson <: BosonLike end
+Base.@pure is_particle(::AntiBoson) = false
+Base.@pure is_anti_particle(::AntiBoson) = true
+
+"""
+Abstract base type for majorana-bosons, i.e. bosons which are their own anti-particles.
+
+!!! note "particle interface"
+    All subtypes of `MajoranaBoson` have 
+    ```julia 
+    is_boson(::MajoranaBoson) = true
+    is_particle(::MajoranaBoson) = true
+    is_anti_particle(::MajoranaBoson) = true
+    ```
+    
+"""
+abstract type MajoranaBoson <: BosonLike end
+Base.@pure is_particle(::MajoranaBoson) = true
+Base.@pure is_anti_particle(::MajoranaBoson) = true
+
+# TODO: is traits for massless and uncharged particles
+# 		This makes the function calls more specialized
+"""
+Concrete type for the *photons* as a particle species. Mostly used for dispatch. 
+
+!!! note "particle interface"
+    Besides being a subtype of `MajoranaBoson`, `Photon` has
+
+    ```julia
+    mass(::Photon) = 0.0
+    charge(::Photon) = 0.0
+    ```
+    
+"""
+struct Photon <: MajoranaBoson end
+mass(::Photon) = 0.0
+charge(::Photon) = 0.0

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -77,7 +77,7 @@ Abstract base type for majorana-fermions, i.e. fermions which are their own anti
 !!! note "particle interface"
     All subtypes of `MajoranaFermion` have 
     ```julia 
-    is_fermion(::Fermion) = true
+    is_fermion(::MajoranaFermion) = true
     is_particle(::MajoranaFermion) = true
     is_anti_particle(::MajoranaFermion) = true
     ```

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -59,7 +59,7 @@ Abstract base type for anti-fermions as distinct from its particle counterpart `
 !!! note "particle interface"
     All subtypes of `AntiFermion` have 
     ```julia 
-    is_fermion(::Fermion) = true
+    is_fermion(::AntiFermion) = true
     is_particle(::AntiFermion) = false
     is_anti_particle(::AntiFermion) = true
     ```

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -12,7 +12,7 @@
     AbstractParticleType <: AbstractParticle
 
 This is the abstract base type for every species of particles. All functionalities defined on subtypes of `AbstractParticleType` should be static, i.e. known at compile time. 
-For adding runtime information, e.g. four-momenta or particle states, to a particle, consider implementing concrete subtype of `AbstractParticle` instead, which may has a type parameter `P<:AbstractParticleType`. See the concrete type `Particle{P,ST,MT}`
+For adding runtime information, e.g. four-momenta or particle states, to a particle, consider implementing a concrete subtype of `AbstractParticle` instead, which may have a type parameter `P<:AbstractParticleType`. See the concrete type `Particle{P,ST,MT}`
 
 Concrete built-in subtypes of `AbstractParticleType` are 
 

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -49,9 +49,9 @@ Abstract base type for fermions as distinct from anti-fermions.
 """
 abstract type Fermion <: FermionLike end
 
-Base.@pure is_particle(::Fermion) = true
+is_particle(::Fermion) = true
 
-Base.@pure is_anti_particle(::Fermion) = false
+is_anti_particle(::Fermion) = false
 
 """
 Abstract base type for anti-fermions as distinct from its particle counterpart `Fermion`.
@@ -67,9 +67,9 @@ Abstract base type for anti-fermions as distinct from its particle counterpart `
 """
 abstract type AntiFermion <: FermionLike end
 
-Base.@pure is_particle(::AntiFermion) = false
+is_particle(::AntiFermion) = false
 
-Base.@pure is_anti_particle(::AntiFermion) = true
+is_anti_particle(::AntiFermion) = true
 
 """
 Abstract base type for majorana-fermions, i.e. fermions which are their own anti-particles.
@@ -85,9 +85,9 @@ Abstract base type for majorana-fermions, i.e. fermions which are their own anti
 """
 abstract type MajoranaFermion <: FermionLike end
 
-Base.@pure is_particle(::MajoranaFermion) = true
+is_particle(::MajoranaFermion) = true
 
-Base.@pure is_anti_particle(::MajoranaFermion) = true
+is_anti_particle(::MajoranaFermion) = true
 
 """
 Concrete type for *electrons* as a particle species. Mostly used for dispatch. 
@@ -143,8 +143,8 @@ Abstract base type for bosons as distinct from its anti-particle counterpart `An
 
 """
 abstract type Boson <: BosonLike end
-Base.@pure is_particle(::Boson) = true
-Base.@pure is_anti_particle(::Boson) = false
+is_particle(::Boson) = true
+is_anti_particle(::Boson) = false
 
 """
 Abstract base type for anti-bosons as distinct from its particle counterpart `Bosons`. 
@@ -159,8 +159,8 @@ Abstract base type for anti-bosons as distinct from its particle counterpart `Bo
 
 """
 abstract type AntiBoson <: BosonLike end
-Base.@pure is_particle(::AntiBoson) = false
-Base.@pure is_anti_particle(::AntiBoson) = true
+is_particle(::AntiBoson) = false
+is_anti_particle(::AntiBoson) = true
 
 """
 Abstract base type for majorana-bosons, i.e. bosons which are their own anti-particles.
@@ -175,8 +175,8 @@ Abstract base type for majorana-bosons, i.e. bosons which are their own anti-par
     
 """
 abstract type MajoranaBoson <: BosonLike end
-Base.@pure is_particle(::MajoranaBoson) = true
-Base.@pure is_anti_particle(::MajoranaBoson) = true
+is_particle(::MajoranaBoson) = true
+is_anti_particle(::MajoranaBoson) = true
 
 """
 Concrete type for the *photons* as a particle species. Mostly used for dispatch. 

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.8.5"
 manifest_format = "2.0"
-project_hash = "71d91126b5a1fb1020e1098d9d492de2a4438fd2"
+project_hash = "84ac8e29f8ef0077a3683e8c5d2cbbf44f698527"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -25,6 +25,11 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
+
+[[deps.SafeTestsets]]
+git-tree-sha1 = "81ec49d645af090901120a1542e67ecbbe044db3"
+uuid = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+version = "0.1.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/interfaces/particle_interface.jl
+++ b/test/interfaces/particle_interface.jl
@@ -1,0 +1,18 @@
+
+
+using QEDprocesses
+
+@testset "default interface" begin
+    struct TestParticle <: AbstractParticle end
+    @test !is_fermion(TestParticle())
+    @test !is_boson(TestParticle())
+    @test is_particle(TestParticle())
+    @test !is_anti_particle(TestParticle())
+end
+
+@testset "hard interface" begin
+    struct TestParticle <: AbstractParticle end
+    @test_throws Exception charge(TestParticle())
+    @test_throws Exception mass(TestParticle())
+    # @test false
+end

--- a/test/interfaces/particle_interface.jl
+++ b/test/interfaces/particle_interface.jl
@@ -14,5 +14,4 @@ end
     struct TestParticle <: AbstractParticle end
     @test_throws Exception charge(TestParticle())
     @test_throws Exception mass(TestParticle())
-    # @test false
 end

--- a/test/particle_types.jl
+++ b/test/particle_types.jl
@@ -1,0 +1,75 @@
+using QEDprocesses
+
+@testset "fermion likes" begin
+    @testset "fermion" begin
+        struct TestFermion <: Fermion end
+        @test is_fermion(TestFermion())
+        @test is_particle(TestFermion())
+        @test !is_anti_particle(TestFermion())
+    end
+
+    @testset "antifermion" begin
+        struct TestAntiFermion <: AntiFermion end
+        @test is_fermion(TestAntiFermion())
+        @test !is_particle(TestAntiFermion())
+        @test is_anti_particle(TestAntiFermion())
+    end
+
+    @testset "majorana fermion" begin
+        struct TestMajoranaFermion <: MajoranaFermion end
+        @test is_fermion(TestMajoranaFermion())
+        @test is_particle(TestMajoranaFermion())
+        @test is_anti_particle(TestMajoranaFermion())
+    end
+
+    @testset "electron" begin
+        @test is_fermion(Electron())
+        @test is_particle(Electron())
+        @test !is_anti_particle(Electron())
+        @test mass(Electron()) == 1.0
+        @test charge(Electron()) == -1.0
+    end
+
+    @testset "positron" begin
+        @test is_fermion(Positron())
+        @test !is_particle(Positron())
+        @test is_anti_particle(Positron())
+        @test mass(Positron()) == 1.0
+        @test charge(Positron()) == 1.0
+    end
+end
+
+@testset "boson likes" begin
+    @testset "boson" begin
+        struct TestBoson <: Boson end
+        @test !is_fermion(TestBoson())
+        @test is_boson(TestBoson())
+        @test is_particle(TestBoson())
+        @test !is_anti_particle(TestBoson())
+    end
+
+    @testset "antiboson" begin
+        struct TestAntiBoson <: AntiBoson end
+        @test !is_fermion(TestAntiBoson())
+        @test is_boson(TestAntiBoson())
+        @test !is_particle(TestAntiBoson())
+        @test is_anti_particle(TestAntiBoson())
+    end
+
+    @testset "majorana boson" begin
+        struct TestMajoranaBoson <: MajoranaBoson end
+        @test !is_fermion(TestMajoranaBoson())
+        @test is_boson(TestMajoranaBoson())
+        @test is_particle(TestMajoranaBoson())
+        @test is_anti_particle(TestMajoranaBoson())
+    end
+
+    @testset "photon" begin
+        @test !is_fermion(Photon())
+        @test is_boson(Photon())
+        @test is_particle(Photon())
+        @test is_anti_particle(Photon())
+        @test charge(Photon()) == 0.0
+        @test mass(Photon()) == 0.0
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using QEDprocesses
-using Test
+using Test 
+using SafeTestsets
 
-@testset "QEDprocesses.jl" begin
-    # Write your tests here.
+begin
+    @safetestset "particle interface" begin include("interfaces/particle_interface.jl") end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,9 @@ using Test
 using SafeTestsets
 
 begin
-    @safetestset "particle interface" begin include("interfaces/particle_interface.jl") end
+    # Interfaces
+    @time @safetestset "particle interface" begin include("interfaces/particle_interface.jl") end
+
+    # modules
+    @time @safetestset "particles types" begin include("particle_types.jl") end
 end


### PR DESCRIPTION
# Generatities
This MR adds a Julia interface including types and functions to describe particles in the sense of the standard model of particle physics. The description is not restricted to static properties, but can in general be fulfilled by any instance of particles in general. 

Furthermore, this MR contains an implementation of a type hierarchy for Bosons, Fermions, and their respective anti-particles, as well as particle types for Electrons, Positrons, and Photons. Again, the type hierarchy is not restricted to these particle types.

# Particles
## Abstract particle interface
In the implementation, the notion of particles is derived from an abstract type `AbstractParticle` and the following interface functions:

* `is_fermion(::AbstractParticle)`, which returns `true` if the input can be considered as a fermion, and `false` if not.
* `is_boson(::AbstractParticle)`, which returns `true` if the input can be considered as a boson, and `false` if not.
* `is_particle(::AbstractParticle)`, which returns `true` if the input can be considered as a *particle*, and `false` if not.
* `is_anti_particle(::AbstractParticle)`, which returns `true` if the input can be considered as an *antiparticle*, and `false` if not.
* `mass(::AbstractParticle)`, which returns the mass of the input (usually as but not restricted to *float*)
* `charge(::AbstractParticle)`, which returns the electric charge of the input (usually as but not restricted to *float*)

For more detailed descriptions, see the respective docstrings.

## Particle type hierarchy 
The abstract type `AbstractParticleType <: AbstractParticle` is the root type for all types of particles, where `type` means, that all subtypes only provide static information about a certain particle species.
Beginning with `AbstractParticleType`, there is a hierarchy of particle types indicating if there are fermions, bosons, and their respective anti-particles. The leaves of the hierarchy tree are the concrete types for `Electrons`, `Positrons`, and `Photons`. 

Within this MR, the particle type hierarchy looks like this:
```mermaid
graph TD
    A(a_AbstractParticleType) --> B1(a_FermionLike)
    B1 --> B11(a_Fermion)
    B11 --> B111(Electron)
    B1 --> B12(a_AntiFermion)
    B12 --> B121(Positron)
    B1 --> B13(a_MajoranaFermion)
    A --> B2(a_BosonLike)
    B2 --> B21(a_Boson)
    B2 --> B22(a_AntiBoson)
    B2 --> B23(a_MajoranaBoson)
    B23 --> B231(Photon)
```
(The leading `a_` indicates that the type is abstract. This was done only here and not in the code.)

It can easily be extended by concrete types to other particles, e.g. Gluons, Higgs, W-, or Z-Bosons as well as Neutrinos, but also quasi-particles like Cooper-pairs or phonons.
Except for `mass` and `charge`, inserting particle types into the hierarchy above will provide default implementations for the particle interface functions.
This means the only interface functions which need to be implemented for additional particles are `mass` and `charge`. For `Electron`, `Positron`, and `Photon`, this is already done.)
Using reasonable defaults, the particle interface can be extended, e.g. by functions like `flavor`, `color_charge`, and so on.  
