### PR TITLE
Model and Process interface

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,29 +1,226 @@
 # This file is machine-generated - editing it directly is not advised
 
-[[Base64]]
+manifest_format = "2.0"
+
+[[deps.ArgCheck]]
+git-tree-sha1 = "a3a402a35a2f7e0b87828ccabbd5ebfbebe356b4"
+uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+version = "2.3.0"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[DocStringExtensions]]
-deps = ["LibGit2"]
-git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
-uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.9.3"
+[[deps.Calculus]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
+uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
+version = "0.5.1"
 
-[[LibGit2]]
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "e30f2f4e20f7f186dc36529910beaedc60cfa644"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.16.0"
+
+[[deps.CommonSolve]]
+git-tree-sha1 = "0eee5eb66b1cf62cd6ad1b460238e60e4b09400c"
+uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+version = "0.2.4"
+
+[[deps.Compat]]
+deps = ["Dates", "LinearAlgebra", "UUIDs"]
+git-tree-sha1 = "e460f044ca8b99be31d35fe54fc33a5c33dd8ed7"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.9.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.0.1+0"
+
+[[deps.ConstructionBase]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "c53fc348ca4d40d7b371e71fd52251839080cbc9"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.5.4"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.6"
+
+[[deps.Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "68772f49f54b479fa88ace904f6127f0a3bb2e46"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.12"
+
+[[deps.LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
-[[NetworkOptions]]
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "9ee1618cbf5240e6d4e0371d6f24065083f60c48"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.11"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.Measurements]]
+deps = ["Calculus", "LinearAlgebra", "Printf", "RecipesBase", "Requires"]
+git-tree-sha1 = "51d946d38d62709d6a2d37ea9bcc30c80c686801"
+uuid = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+version = "2.9.0"
+
+[[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
-[[Printf]]
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.20+0"
+
+[[deps.PhysicalConstants]]
+deps = ["Measurements", "Roots", "Unitful"]
+git-tree-sha1 = "cd4da9d1890bc2204b08fe95ebafa55e9366ae4e"
+uuid = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
+version = "0.2.3"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.0"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.0"
+
+[[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
-[[SHA]]
+[[deps.QEDbase]]
+deps = ["ArgCheck", "ConstructionBase", "DocStringExtensions", "LinearAlgebra", "PhysicalConstants", "Random", "SimpleTraits", "StaticArrays"]
+git-tree-sha1 = "d8869c0f04734347f3f906e0498f25dc223a054c"
+uuid = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
+version = "0.1.4"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.RecipesBase]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "5c3d09cc4f31f5fc6af001c250bf1278733100ff"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.3.4"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
+
+[[deps.Roots]]
+deps = ["ChainRulesCore", "CommonSolve", "Printf", "Setfield"]
+git-tree-sha1 = "ff42754a57bb0d6dcfe302fd0d4272853190421f"
+uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+version = "2.0.19"
+
+[[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
 
-[[Unicode]]
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Setfield]]
+deps = ["ConstructionBase", "Future", "MacroTools", "StaticArraysCore"]
+git-tree-sha1 = "e2cc6d8c88613c05e1defb55170bf5ff211fbeac"
+uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+version = "1.1.1"
+
+[[deps.SimpleTraits]]
+deps = ["InteractiveUtils", "MacroTools"]
+git-tree-sha1 = "5d7e3f4e11935503d3ecaf7186eac40602e7d231"
+uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+version = "0.9.4"
+
+[[deps.SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
+git-tree-sha1 = "51621cca8651d9e334a659443a74ce50a3b6dfab"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.6.3"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "36b3d696ce6366023a0ea192b4cd442268995a0d"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.2"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.Unitful]]
+deps = ["ConstructionBase", "Dates", "InverseFunctions", "LinearAlgebra", "Random"]
+git-tree-sha1 = "a72d22c7e13fe2de562feda8645aa134712a87ee"
+uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
+version = "1.17.0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.1.1+0"

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
 
 [compat]
 julia = "1.9"

--- a/README.md
+++ b/README.md
@@ -33,3 +33,21 @@ To install the locally downloaded package on Windows, change to the parent direc
 ```julia
 (@v1.9) pkg> add ./QEDprocesses.jl
 ```
+
+## Building the documentation locally
+
+To build the documentation of `QEDprocesses.jl` locally, first clone this
+repository. Then, you instantiate the documentation subpackage by hitting 
+
+```julia 
+julia --project=docs -e 'using Pkg; Pkg.instantiate(); Pkg.develop(PackageSpec(path=pwd()))'
+```
+in the root directory of this repository. Afterwards, the dokumentation can be
+built by running
+
+```julia
+julia --project=docs --color=yes docs/make.jl
+```
+
+To access the documentation site, just open the file `docs/_build/index.html` in
+your favorite browser. 

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -9,8 +9,50 @@ git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
 uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
 version = "0.0.1"
 
+[[deps.ArgCheck]]
+git-tree-sha1 = "a3a402a35a2f7e0b87828ccabbd5ebfbebe356b4"
+uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+version = "2.3.0"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.Calculus]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
+uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
+version = "0.5.1"
+
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "e30f2f4e20f7f186dc36529910beaedc60cfa644"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.16.0"
+
+[[deps.CommonSolve]]
+git-tree-sha1 = "0eee5eb66b1cf62cd6ad1b460238e60e4b09400c"
+uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+version = "0.2.4"
+
+[[deps.Compat]]
+deps = ["Dates", "LinearAlgebra", "UUIDs"]
+git-tree-sha1 = "e460f044ca8b99be31d35fe54fc33a5c33dd8ed7"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.9.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.0.1+0"
+
+[[deps.ConstructionBase]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "c53fc348ca4d40d7b371e71fd52251839080cbc9"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.5.4"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -18,15 +60,19 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [[deps.DocStringExtensions]]
 deps = ["LibGit2"]
-git-tree-sha1 = "2fb1e02f2b635d0845df5d7c167fec4dd739b00d"
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.9.3"
+version = "0.8.6"
 
 [[deps.Documenter]]
 deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
 git-tree-sha1 = "58fea7c536acd71f3eef6be3b21c0df5f3df88fd"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "0.27.24"
+
+[[deps.Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[deps.IOCapture]]
 deps = ["Logging", "Random"]
@@ -38,6 +84,12 @@ version = "0.2.3"
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[deps.InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "68772f49f54b479fa88ace904f6127f0a3bb2e46"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.12"
+
 [[deps.JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
 git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
@@ -48,12 +100,31 @@ version = "0.21.4"
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "9ee1618cbf5240e6d4e0371d6f24065083f60c48"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.11"
 
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.Measurements]]
+deps = ["Calculus", "LinearAlgebra", "Printf", "RecipesBase", "Requires"]
+git-tree-sha1 = "51d946d38d62709d6a2d37ea9bcc30c80c686801"
+uuid = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+version = "2.9.0"
 
 [[deps.Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -62,17 +133,28 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.20+0"
+
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "5a6ab2f64388fd1175effdf73fe5933ef1e0bac0"
+git-tree-sha1 = "716e24b21538abc91f6205fd1d8363f39b442851"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.7.0"
+version = "2.7.2"
+
+[[deps.PhysicalConstants]]
+deps = ["Measurements", "Roots", "Unitful"]
+git-tree-sha1 = "cd4da9d1890bc2204b08fe95ebafa55e9366ae4e"
+uuid = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
+version = "0.2.3"
 
 [[deps.PrecompileTools]]
 deps = ["Preferences"]
-git-tree-sha1 = "9673d39decc5feece56ef3940e5dafba15ba0f81"
+git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
 uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-version = "1.1.2"
+version = "1.2.0"
 
 [[deps.Preferences]]
 deps = ["TOML"]
@@ -84,8 +166,15 @@ version = "1.4.0"
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[[deps.QEDbase]]
+deps = ["ArgCheck", "ConstructionBase", "DocStringExtensions", "LinearAlgebra", "PhysicalConstants", "Random", "SimpleTraits", "StaticArrays"]
+git-tree-sha1 = "d8869c0f04734347f3f906e0498f25dc223a054c"
+uuid = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
+version = "0.1.4"
+
 [[deps.QEDprocesses]]
-path = ".."
+deps = ["DocStringExtensions", "QEDbase"]
+path = "/Users/uwe/Work/jlProjects/QEDjl-project/forks/QEDprocesses.jl"
 uuid = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
 version = "0.1.0"
 
@@ -97,6 +186,24 @@ uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
+[[deps.RecipesBase]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "5c3d09cc4f31f5fc6af001c250bf1278733100ff"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.3.4"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
+
+[[deps.Roots]]
+deps = ["ChainRulesCore", "CommonSolve", "Printf", "Setfield"]
+git-tree-sha1 = "ff42754a57bb0d6dcfe302fd0d4272853190421f"
+uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+version = "2.0.19"
+
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 version = "0.7.0"
@@ -104,8 +211,39 @@ version = "0.7.0"
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[deps.Setfield]]
+deps = ["ConstructionBase", "Future", "MacroTools", "StaticArraysCore"]
+git-tree-sha1 = "e2cc6d8c88613c05e1defb55170bf5ff211fbeac"
+uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+version = "1.1.1"
+
+[[deps.SimpleTraits]]
+deps = ["InteractiveUtils", "MacroTools"]
+git-tree-sha1 = "5d7e3f4e11935503d3ecaf7186eac40602e7d231"
+uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+version = "0.9.4"
+
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
+git-tree-sha1 = "51621cca8651d9e334a659443a74ce50a3b6dfab"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.6.3"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "36b3d696ce6366023a0ea192b4cd442268995a0d"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.2"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -122,3 +260,14 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.Unitful]]
+deps = ["ConstructionBase", "Dates", "InverseFunctions", "LinearAlgebra", "Random"]
+git-tree-sha1 = "a72d22c7e13fe2de562feda8645aa134712a87ee"
+uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
+version = "1.17.0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.1.1+0"

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -4,8 +4,6 @@ export AbstractParticle
 export is_fermion, is_boson, is_particle, is_anti_particle
 export mass, charge
 
-<<<<<<< HEAD
-# particle types
 export AbstractParticleType
 export FermionLike, Fermion, AntiFermion, MajoranaFermion
 export BosonLike, Boson, AntiBoson, MajoranaBoson

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -4,13 +4,26 @@ export AbstractParticle
 export is_fermion, is_boson, is_particle, is_anti_particle
 export mass, charge
 
+# Abstract model interface
+export AbstractModelDefinition, fundamental_interaction_type
+
+# Abstract process interface
+export AbstractProcessDefinition, incoming_particles, outgoing_particles
+export initial_phasespace_dimension, final_phasespace_dimension
+export number_incoming_particles, number_outgoing_particles 
+export differential_cross_section, total_cross_section
+
+# particle types
 export AbstractParticleType
 export FermionLike, Fermion, AntiFermion, MajoranaFermion
 export BosonLike, Boson, AntiBoson, MajoranaBoson
 export Electron, Positron, Photon
 
 using DocStringExtensions
+using QEDbase
 
 include("interfaces/particle_interface.jl")
+include("interfaces/model_interface.jl")
+include("interfaces/process_interface.jl")
 include("particle_types.jl")
 end

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -1,10 +1,10 @@
 module QEDprocesses
 
-# Abstract particle interface
 export AbstractParticle
 export is_fermion, is_boson, is_particle, is_anti_particle
 export mass, charge
 
+<<<<<<< HEAD
 # particle types
 export AbstractParticleType
 export FermionLike, Fermion, AntiFermion, MajoranaFermion

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -22,6 +22,7 @@ export Electron, Positron, Photon
 using DocStringExtensions
 using QEDbase
 
+include("utils.jl")
 include("interfaces/particle_interface.jl")
 include("interfaces/model_interface.jl")
 include("interfaces/process_interface.jl")

--- a/src/interfaces/model_interface.jl
+++ b/src/interfaces/model_interface.jl
@@ -1,0 +1,28 @@
+###############
+# The model interface
+#
+# In this file, we define the interface of working with compute models in
+# general.
+# 
+# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
+# ecosystem.
+#
+###############
+# root type for models
+"""
+Abstract base type for all compute model definitions in the context of scattering processes. Every subtype of `AbstractModelDefinition` is associated with a fundamental interaction. 
+Therefore, one needs to implement the following soft interface function
+
+```Julia
+fundamental_interaction_type(::AbstractModelDefinition)
+```
+"""
+abstract type AbstractModelDefinition end
+
+"""
+
+    fundamental_interaction_type(models_def::AbstractModelDefinition)
+
+Return the fundamental interaction associated with the passed model definition.
+"""
+function fundamental_interaction_type end

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -11,8 +11,8 @@
 
 
 """
-Abstract base type for every type which might be considered a *particle* in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of interface functions implemented: static functions and property functions. 
-The static functions provide information on what kind of particle it is (defaults are written in square brackets)
+Abstract base type for every type which might be considered as a `particle` in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of functions implemented: static functions and property functions. 
+The static functions say something, what kind of particle it is (defaults are written in square brackets)
 
 ```julia
     is_fermion(::AbstractParticle)::Bool [= false]
@@ -21,13 +21,13 @@ The static functions provide information on what kind of particle it is (default
     is_anti_particle(::AbstractParticle)::Bool [= false]
 ``` 
 If the output of those functions differ from the defaults for a subtype of `AbstractParticle`, these functions need to be overwritten.
-The second type of functions define a hard interface for `AbstractParticle`:
+The second type of functions define a soft interface `AbstractParticle`:
 
 ```julia
     mass(::AbstractParticle)::Real
     charge(::AbstractParticle)::Real
 ```
-These functions must be implemented in order to have the subtype of `AbstractParticle` work with the functionalities of `QEDprocesses.jl`.
+These functions need to be implemented in order to have the subtype of `AbstractParticle` work with the functionalities of `QEDprocesses.jl`.
 """
 abstract type AbstractParticle end
 

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -64,27 +64,21 @@ The default implementation of `is_anti_particle` for every subtype of `AbstractP
 is_anti_particle(::AbstractParticle) = false
 
 """
-    $(TYPEDSIGNATURES)
+    
+    mass(particle::AbstractParticle)::Real
 
 Interface function for particles. Return the rest mass of a particle (in units of the electron mass).
 
-This needs to be implemented for each concrete subtype of `AbstractParticle` and will throw an error otherwise.
+This needs to be implemented for each concrete subtype of `AbstractParticle`.
 """
-function mass(particle::AbstractParticle)::Real
-    return error(
-        "The function mass($(typeof(particle))) is not implemented. You need to implement it to use the particle interface.",
-    )
-end
+function mass end
 
 """
-    $(TYPEDSIGNATURES)
+    
+    charge(::AbstractParticle)::Real
 
 Interface function for particles. Return the electric charge of a particle (in units of the elementary electric charge).
 
-This needs to be implemented for each concrete subtype of `AbstractParticle` and will throw an error otherwise.
+This needs to be implemented for each concrete subtype of `AbstractParticle`.
 """
-function charge(::AbstractParticle)::Real
-    return error(
-        "The function charge($(typeof(particle))) is not implemented. You need to implement it to use the particle interface.",
-    )
-end
+function charge end

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -11,7 +11,7 @@
 
 
 """
-Abstract base type for every type which might be considered as a `particle` in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of functions implemented: static functions and property functions. 
+Abstract base type for every type which might be considered as a `particle` in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of interface functions implemented: static functions and property functions. 
 The static functions provide information on what kind of particle it is (defaults are written in square brackets)
 
 ```julia
@@ -21,13 +21,13 @@ The static functions provide information on what kind of particle it is (default
     is_anti_particle(::AbstractParticle)::Bool [= false]
 ``` 
 If the output of those functions differ from the defaults for a subtype of `AbstractParticle`, these functions need to be overwritten.
-The second type of functions define a soft interface `AbstractParticle`:
+The second type of functions define a hard interface for `AbstractParticle`:
 
 ```julia
     mass(::AbstractParticle)::Real
     charge(::AbstractParticle)::Real
 ```
-These functions need to be implemented in order to have the subtype of `AbstractParticle` work with the functionalities of `QEDprocesses.jl`.
+These functions must be implemented in order to have the subtype of `AbstractParticle` work with the functionalities of `QEDprocesses.jl`.
 """
 abstract type AbstractParticle end
 

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -12,7 +12,7 @@
 
 """
 Abstract base type for every type which might be considered as a `particle` in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of functions implemented: static functions and property functions. 
-The static functions say something, what kind of particle it is (defaults are written in square brackets)
+The static functions provide information on what kind of particle it is (defaults are written in square brackets)
 
 ```julia
     is_fermion(::AbstractParticle)::Bool [= false]

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -11,7 +11,7 @@
 
 
 """
-Abstract base type for every type which might be considered as a `particle` in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of interface functions implemented: static functions and property functions. 
+Abstract base type for every type which might be considered a *particle* in the context of `QED.jl`. For every (concrete) subtype of `AbstractParticle`, there are two kinds of interface functions implemented: static functions and property functions. 
 The static functions provide information on what kind of particle it is (defaults are written in square brackets)
 
 ```julia

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -66,8 +66,8 @@ end
     _differential_cross_section(
         proc_def::AbstractProcessDefinition,
         model_def::AbstractModelDefinition,
-        initPS::AbstractVector{T},
-        finalPS::AbstractVector{T},
+        init_phasespace::AbstractVector{T},
+        final_phasespace::AbstractVector{T},
     ) where {T<:QEDbase.AbstractFourMomentum}
 
 Interface function for the combination of scattering processes and models. Return the differential cross section of a 
@@ -81,9 +81,9 @@ check if the length of the passed phase spaces match the respective number of pa
 
     ```julia
 
-    _differential_cross_section(proc_def,model_def,initPS::AbstractVector{T},finialPS::AbstractMatrix{T})
-    _differential_cross_section(proc_def,model_def,initPS::AbstractMatrix{T},finialPS::AbstractVector{T})
-    _differential_cross_section(proc_def,model_def,initPS::AbstractMatrix{T},finialPS::AbstractMatrix{T})
+    _differential_cross_section(proc_def,model_def,init_phasespace::AbstractVector{T},finial_phasespace::AbstractMatrix{T})
+    _differential_cross_section(proc_def,model_def,init_phasespace::AbstractMatrix{T},finial_phasespace::AbstractVector{T})
+    _differential_cross_section(proc_def,model_def,init_phasespace::AbstractMatrix{T},finial_phasespace::AbstractMatrix{T})
 
     ```
 
@@ -105,8 +105,8 @@ function _differential_cross_section end
     differential_cross_section(
         proc_def::AbstractProcessDefinition,
         model_def::AbstractModelDefinition,
-        initPS::Union{AbstractVector{T},AbstractMatrix{T}},
-        finalPS::Union{AbstractVector{T},AbstractMatrix{T}},
+        init_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
+        final_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
     ) where {T<:QEDbase.AbstractFourMomentum}
 
 Return the differential cross section for a given combination of a scattering process 
@@ -117,75 +117,72 @@ This function will eventually call the respective interface function [`_differen
 function differential_cross_section(
     proc_def::AbstractProcessDefinition,
     model_def::AbstractModelDefinition,
-    initPS::Union{AbstractVector{T},AbstractMatrix{T}},
-    finalPS::Union{AbstractVector{T},AbstractMatrix{T}},
+    init_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
+    final_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
     ) where {T<:QEDbase.AbstractFourMomentum}
-    size(initPS, 1) == number_incoming_pariticles(proc_def) || throw(
-        DimensionMismatch("The number of momenta in the initial phasespace <{length(initPS)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
+    size(init_phasespace, 1) == number_incoming_pariticles(proc_def) || throw(
+        DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
                                                                                )
-    size(finalPS, 1) == number_outgoing_pariticles(proc_def) || throw(
-        DimensionMismatch("The number of momenta in the final phasespace <{length(finalPS)}> does not match the number of incoming particles of the process <{number_outgoing_pariticles(proc_def)}>."),
+    size(final_phasespace, 1) == number_outgoing_pariticles(proc_def) || throw(
+        DimensionMismatch("The number of momenta in the final phasespace <{length(final_phasespace)}> does not match the number of incoming particles of the process <{number_outgoing_pariticles(proc_def)}>."),
     )
-    return _differential_cross_section(proc_def, model_def, initPS, finalPS)
+    return _differential_cross_section(proc_def, model_def, init_phasespace, final_phasespace)
 end
 
 # returns diffCS for single `initPS` and several `finalPS` points without input-check
 function _differential_cross_section(
     proc_def::AbstractProcessDefinition,
     model_def::AbstractModelDefinition,
-    initPS::AbstractVector{T},
-    finalPS::AbstractMatrix{T},
+    init_phasespace::AbstractVector{T},
+    final_phasespace::AbstractMatrix{T},
 ) where {T<:QEDbase.AbstractFourMomentum}
-    res = Vector{eltype(initPS[1])}(undef, size(finalPS, 2))
-    for i in 1:size(finalPS, 2)
+    res = Vector{eltype(init_phasespace[1])}(undef, size(final_phasespace, 2))
+    for i in 1:size(final_phasespace, 2)
         res[i] = _differential_cross_section(
-            proc_def, model_def, initPS, view(finalPS, :, i)
+            proc_def, model_def, init_phasespace, view(final_phasespace, :, i)
         )
     end
     return res
 end
 
-# returns diffCS for several `initPS` and a single `finalPS` points without input-check
 function _differential_cross_section(
     proc_def::AbstractProcessDefinition,
     model_def::AbstractModelDefinition,
-    initPS::AbstractMatrix{T},
-    finalPS::AbstractVector{T},
+    init_phasespace::AbstractMatrix{T},
+    final_phasespace::AbstractVector{T},
 ) where {T<:QEDbase.AbstractFourMomentum}
-res = Vector{eltype(initPS[1])}(undef, size(initPS, 2))
-    for i in 1:size(initPS, 2)
+res = Vector{eltype(init_phasespace[1])}(undef, size(init_phasespace, 2))
+    for i in 1:size(init_phasespace, 2)
         res[i] = _differential_cross_section(
-            proc_def, model_def, view(initPS, :, i), finalPS
+            proc_def, model_def, view(init_phasespace, :, i), final_phasespace
         )
     end
     return res
 end
 
-# returns diffCS for several `initPS` and several `finalPS` points without input-check
 function _differential_cross_section(
     proc_def::AbstractProcessDefinition,
     model_def::AbstractModelDefinition,
-    initPS::AbstractMatrix{T},
-    finalPS::AbstractMatrix{T},
+    init_phasespace::AbstractMatrix{T},
+    final_phasespace::AbstractMatrix{T},
 ) where {T<:QEDbase.AbstractFourMomentum}
-res = Matrix{eltype(initPS[1])}(undef, size(initPS, 2), size(finalPS, 2))
-    for init_idx in 1:size(initPS, 2)
-        for final_idx in 1:size(finalPS, 2)
+res = Matrix{eltype(init_phasespace[1])}(undef, size(init_phasespace, 2), size(final_phasespace, 2))
+    for init_idx in 1:size(init_phasespace, 2)
+        for final_idx in 1:size(final_phasespace, 2)
             res[init_idx, final_idx] = _differential_cross_section(
-                proc_def, model_def, view(initPS, :, init_idx), view(finalPS, :, final_idx)
+                proc_def, model_def, view(init_phasespace, :, init_idx), view(final_phasespace, :, final_idx)
             )
         end
     end
     return res
 end
 
-# returns the totalCS for a given `initPS` point without input-check
 """
 
     _total_cross_section(
         proc_def::AbstractProcessDefinition,
         model_def::AbstractModelDefinition,
-        initPS::AbstractVector{T},
+        init_phasespace::AbstractVector{T},
     ) where {T<:QEDbase.AbstractFourMomentum} end
 
 Interface function for the combination of scattering processes and models. Return the total cross section of a 
@@ -199,7 +196,7 @@ check if the length of the passed initial phase spaces match number of incoming 
 
     ```julia
 
-    _total_cross_section(proc_def,model_def,initPS::AbstractMatrix{T})
+    _total_cross_section(proc_def,model_def,init_phasespace::AbstractMatrix{T})
 
     ```
 
@@ -219,11 +216,11 @@ function _total_cross_section end
 function _total_cross_section(
     proc_def::AbstractProcessDefinition,
     model_def::AbstractModelDefinition,
-    initPS::AbstractMatrix{T},
+    init_phasespace::AbstractMatrix{T},
 ) where {T<:QEDbase.AbstractFourMomentum}
-res = Vector{eltype(initPS[1])}(undef, size(initPS, 2))
+res = Vector{eltype(init_phasespace[1])}(undef, size(init_phasespace, 2))
     for i in 1:size(initPS, 2)
-        res[i] = _total_cross_section(proc_def, model_def, view(initPS, :, i))
+        res[i] = _total_cross_section(proc_def, model_def, view(init_phasespace, :, i))
     end
     return res
 end
@@ -233,7 +230,7 @@ end
     total_cross_section(
         proc_def::AbstractProcessDefinition,
         model_def::AbstractModelDefinition,
-        initPS::Union{AbstractVector{T},AbstractMatrix{T}},
+        init_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
     ) where {T<:QEDbase.AbstractFourMomentum}
 
 Return the total cross section for a combination of a scattering process and a compute model evaluated on a given initial phase space. 
@@ -244,10 +241,10 @@ This function will eventually call the respective interface function [`_total_cr
 function total_cross_section(
     proc_def::AbstractProcessDefinition,
     model_def::AbstractModelDefinition,
-    initPS::Union{AbstractVector{T},AbstractMatrix{T}},
+    init_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
 ) where {T<:QEDbase.AbstractFourMomentum}
-    size(initPS, 1) == number_incoming_pariticles(proc_def) || throw(
-        DimensionMismatch("The number of momenta in the initial phasespace <{length(initPS)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
+    size(init_phasespace, 1) == number_incoming_pariticles(proc_def) || throw(
+        DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
     )
-    return _total_cross_section(proc_def, model_def, initPS)
+    return _total_cross_section(proc_def, model_def, init_phasespace)
 end

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -219,7 +219,7 @@ function _total_cross_section(
     init_phasespace::AbstractMatrix{T},
 ) where {T<:QEDbase.AbstractFourMomentum}
 res = Vector{_base_component_type(init_phasespace)}(undef, size(init_phasespace, 2))
-    for i in 1:size(initPS, 2)
+    for i in 1:size(init_phasespace, 2)
         res[i] = _total_cross_section(proc_def, model_def, view(init_phasespace, :, i))
     end
     return res

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -87,7 +87,7 @@ check if the length of the passed phase spaces match the respective number of pa
 
     ```
 
-    where `T<:QEDbase.AbstractFourMomentum`. Although, any combinations of initial and final phase spaces given by *single points* and *vector of points* 
+    where `T<:QEDbase.AbstractFourMomentum`. Although, any combinations of initial and final phase space types given by *single set of points* (AbstractVector{T}) and *mutiple set of points* (AbstractMatrix{T}) 
     is implemented. Furthermore, a safe version of `_differential_cross_section` is also implemented: [`differential_cross_section`](@ref).
 
 !!! note "unsafe implementation"

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -1,7 +1,7 @@
 ###############
 # The process interface
 #
-# In this file, we define the interface of working with scattering processes in
+# In this file, we define the interface for working with scattering processes in
 # general.
 # 
 # This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -122,7 +122,7 @@ function differential_cross_section(
     ) where {T<:QEDbase.AbstractFourMomentum}
     size(init_phasespace, 1) == number_incoming_pariticles(proc_def) || throw(
         DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
-                                                                               )
+    )
     size(final_phasespace, 1) == number_outgoing_pariticles(proc_def) || throw(
         DimensionMismatch("The number of momenta in the final phasespace <{length(final_phasespace)}> does not match the number of incoming particles of the process <{number_outgoing_pariticles(proc_def)}>."),
     )

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -72,7 +72,7 @@ end
 
 Interface function for the combination of scattering processes and models. Return the differential cross section of a 
 given process and model for a passed initial and final phase space. The elements of the `AbstractVector` representing the phase spaces 
-are the momenta of the respective paricles. The implementation of this function for a concrete process and model must not 
+are the momenta of the respective particles. The implementation of this function for a concrete process and model must not 
 check if the length of the passed phase spaces match the respective number of particles. 
 
 !!! note "differential cross section interface"

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -206,7 +206,7 @@ check if the length of the passed initial phase spaces match number of incoming 
 
 !!! note 
     
-    Each instance of this function do not check the validity of the input. 
+    Each instance of this function does not check the validity of the input. 
     This function is not exported and should be used with caution. To add a method in order to implement the cross section interface, 
     it is recommented to directly use `QEDprocesses._total_cross_section` instead of globally `using QEDprocesses: _total_cross_section`.
 

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -110,7 +110,7 @@ function _differential_cross_section end
     ) where {T<:QEDbase.AbstractFourMomentum}
 
 Return the differential cross section for a given combination of a scattering process 
-and model definition evaluated in the passed inital and final phase space. 
+and model definition evaluated on the passed inital and final phase space points. 
 
 This function will eventually call the respective interface function [`_differential_cross_section`](@ref).
 """

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -10,7 +10,7 @@
 ###############
 
 """
-Abstact base type for definitions of scattering processes. It is the root type for the 
+Abstract base type for definitions of scattering processes. It is the root type for the 
 process interface, which assumes that every subtype of `AbstractProcessDefinition`
 implements at least 
 

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -187,7 +187,7 @@ end
 
 Interface function for the combination of scattering processes and models. Return the total cross section of a 
 given process and model for a passed initial phase space. The elements of the `AbstractVector` representing the initial phase space
-are the momenta of the respective paricles. The implementation of this function for a concrete process and model must not 
+are the momenta of the respective particles. The implementation of this function for a concrete process and model must not 
 check if the length of the passed initial phase spaces match number of incoming particles. 
 
 !!! note "cross section interface"

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -136,7 +136,7 @@ function _differential_cross_section(
     init_phasespace::AbstractVector{T},
     final_phasespace::AbstractMatrix{T},
 ) where {T<:QEDbase.AbstractFourMomentum}
-    res = Vector{eltype(init_phasespace[1])}(undef, size(final_phasespace, 2))
+    res = Vector{_base_component_type(init_phasespace)}(undef, size(final_phasespace, 2))
     for i in 1:size(final_phasespace, 2)
         res[i] = _differential_cross_section(
             proc_def, model_def, init_phasespace, view(final_phasespace, :, i)
@@ -151,7 +151,7 @@ function _differential_cross_section(
     init_phasespace::AbstractMatrix{T},
     final_phasespace::AbstractVector{T},
 ) where {T<:QEDbase.AbstractFourMomentum}
-res = Vector{eltype(init_phasespace[1])}(undef, size(init_phasespace, 2))
+res = Vector{_base_component_type(init_phasespace)}(undef, size(init_phasespace, 2))
     for i in 1:size(init_phasespace, 2)
         res[i] = _differential_cross_section(
             proc_def, model_def, view(init_phasespace, :, i), final_phasespace
@@ -166,7 +166,7 @@ function _differential_cross_section(
     init_phasespace::AbstractMatrix{T},
     final_phasespace::AbstractMatrix{T},
 ) where {T<:QEDbase.AbstractFourMomentum}
-res = Matrix{eltype(init_phasespace[1])}(undef, size(init_phasespace, 2), size(final_phasespace, 2))
+res = Matrix{_base_component_type(init_phasespace)}(undef, size(init_phasespace, 2), size(final_phasespace, 2))
     for init_idx in 1:size(init_phasespace, 2)
         for final_idx in 1:size(final_phasespace, 2)
             res[init_idx, final_idx] = _differential_cross_section(
@@ -218,7 +218,7 @@ function _total_cross_section(
     model_def::AbstractModelDefinition,
     init_phasespace::AbstractMatrix{T},
 ) where {T<:QEDbase.AbstractFourMomentum}
-res = Vector{eltype(init_phasespace[1])}(undef, size(init_phasespace, 2))
+res = Vector{_base_component_type(init_phasespace)}(undef, size(init_phasespace, 2))
     for i in 1:size(initPS, 2)
         res[i] = _total_cross_section(proc_def, model_def, view(init_phasespace, :, i))
     end

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -1,0 +1,253 @@
+###############
+# The process interface
+#
+# In this file, we define the interface of working with scattering processes in
+# general.
+# 
+# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
+# ecosystem.
+#
+###############
+
+"""
+Abstact base type for definitions of scattering processes. It is the root type for the 
+process interface, which assumes that every subtype of `AbstractProcessDefinition`
+implements at least 
+
+```Julia
+incoming_particles(proc_def::AbstractProcessDefinition)
+outgoing_particles(proc_def::AbstractProcessDefinition)
+```
+
+which return a tuple of the incoming and outgoing particles, respectively.
+"""
+abstract type AbstractProcessDefinition end
+
+"""
+
+    incoming_particles(proc_def::AbstractProcessDefinition)
+
+Interface function for scattering processes. Return a tuple of the incoming particles for the given process definition.
+This function needs to be given to implement the scattering process interface.
+"""
+function incoming_particles end
+
+"""
+
+    outgoing_particles(proc_def::AbstractProcessDefinition)
+
+Interface function for scattering processes. Return the tuple of outgoing particles for the given process definition.
+This function needs to be given to implement the scattering process interface.
+"""
+function outgoing_particles end
+
+"""
+
+    $(TYPEDSIGNATURES)
+
+Return the number of incoming particles of a given process. 
+"""
+@inline function number_incoming_pariticles(proc_def::AbstractProcessDefinition)
+    return length(incoming_particles(proc_def))
+end
+
+"""
+
+    $(TYPEDSIGNATURES)
+
+Return the number of outgoing particles of a given process. 
+"""
+@inline function number_outgoing_pariticles(proc_def::AbstractProcessDefinition)
+    return length(outgoing_particles(proc_def))
+end
+
+"""
+
+    _differential_cross_section(
+        proc_def::AbstractProcessDefinition,
+        model_def::AbstractModelDefinition,
+        initPS::AbstractVector{T},
+        finalPS::AbstractVector{T},
+    ) where {T<:QEDbase.AbstractFourMomentum}
+
+Interface function for the combination of scattering processes and models. Return the differential cross section of a 
+given process and model for a passed initial and final phase space. The elements of the `AbstractVector` representing the phase spaces 
+are the momenta of the respective paricles. The implementation of this function for a concrete process and model must not 
+check if the length of the passed phase spaces match the respective number of particles. 
+
+!!! note "differential cross section interface"
+
+    Given an implementation of this method, the following *unsafe* generic implementations are provided:
+
+    ```julia
+
+    _differential_cross_section(proc_def,model_def,initPS::AbstractVector{T},finialPS::AbstractMatrix{T})
+    _differential_cross_section(proc_def,model_def,initPS::AbstractMatrix{T},finialPS::AbstractVector{T})
+    _differential_cross_section(proc_def,model_def,initPS::AbstractMatrix{T},finialPS::AbstractMatrix{T})
+
+    ```
+
+    where `T<:QEDbase.AbstractFourMomentum`. Although, any combinations of initial and final phase spaces given by *single points* and *vector of points* 
+    is implemented. Furthermore, a safe version of `_differential_cross_section` is also implemented: [`differential_cross_section`](@ref).
+
+!!! note "unsafe implementation"
+    
+    Each instance of this function do not check the validity of the input. 
+    Therefore, these functions are not exported and should be used with caution. To add a method in order to implement the cross section interface, 
+    it is recommented to directly use `QEDprocesses._differential_cross_section` instead of globally `using QEDprocesses: _differential_cross_section`.
+
+
+"""
+function _differential_cross_section end
+
+"""
+    
+    differential_cross_section(
+        proc_def::AbstractProcessDefinition,
+        model_def::AbstractModelDefinition,
+        initPS::Union{AbstractVector{T},AbstractMatrix{T}},
+        finalPS::Union{AbstractVector{T},AbstractMatrix{T}},
+    ) where {T<:QEDbase.AbstractFourMomentum}
+
+Return the differential cross section for a given combination of a scattering process 
+and model definition evaluated in the passed inital and final phase space. 
+
+This function will eventually call the respective interface function [`_differential_cross_section`](@ref).
+"""
+function differential_cross_section(
+    proc_def::AbstractProcessDefinition,
+    model_def::AbstractModelDefinition,
+    initPS::Union{AbstractVector{T},AbstractMatrix{T}},
+    finalPS::Union{AbstractVector{T},AbstractMatrix{T}},
+    ) where {T<:QEDbase.AbstractFourMomentum}
+    size(initPS, 1) == number_incoming_pariticles(proc_def) || throw(
+        DimensionMismatch("The number of momenta in the initial phasespace <{length(initPS)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
+                                                                               )
+    size(finalPS, 1) == number_outgoing_pariticles(proc_def) || throw(
+        DimensionMismatch("The number of momenta in the final phasespace <{length(finalPS)}> does not match the number of incoming particles of the process <{number_outgoing_pariticles(proc_def)}>."),
+    )
+    return _differential_cross_section(proc_def, model_def, initPS, finalPS)
+end
+
+# returns diffCS for single `initPS` and several `finalPS` points without input-check
+function _differential_cross_section(
+    proc_def::AbstractProcessDefinition,
+    model_def::AbstractModelDefinition,
+    initPS::AbstractVector{T},
+    finalPS::AbstractMatrix{T},
+) where {T<:QEDbase.AbstractFourMomentum}
+    res = Vector{eltype(initPS[1])}(undef, size(finalPS, 2))
+    for i in 1:size(finalPS, 2)
+        res[i] = _differential_cross_section(
+            proc_def, model_def, initPS, view(finalPS, :, i)
+        )
+    end
+    return res
+end
+
+# returns diffCS for several `initPS` and a single `finalPS` points without input-check
+function _differential_cross_section(
+    proc_def::AbstractProcessDefinition,
+    model_def::AbstractModelDefinition,
+    initPS::AbstractMatrix{T},
+    finalPS::AbstractVector{T},
+) where {T<:QEDbase.AbstractFourMomentum}
+res = Vector{eltype(initPS[1])}(undef, size(initPS, 2))
+    for i in 1:size(initPS, 2)
+        res[i] = _differential_cross_section(
+            proc_def, model_def, view(initPS, :, i), finalPS
+        )
+    end
+    return res
+end
+
+# returns diffCS for several `initPS` and several `finalPS` points without input-check
+function _differential_cross_section(
+    proc_def::AbstractProcessDefinition,
+    model_def::AbstractModelDefinition,
+    initPS::AbstractMatrix{T},
+    finalPS::AbstractMatrix{T},
+) where {T<:QEDbase.AbstractFourMomentum}
+res = Matrix{eltype(initPS[1])}(undef, size(initPS, 2), size(finalPS, 2))
+    for init_idx in 1:size(initPS, 2)
+        for final_idx in 1:size(finalPS, 2)
+            res[init_idx, final_idx] = _differential_cross_section(
+                proc_def, model_def, view(initPS, :, init_idx), view(finalPS, :, final_idx)
+            )
+        end
+    end
+    return res
+end
+
+# returns the totalCS for a given `initPS` point without input-check
+"""
+
+    _total_cross_section(
+        proc_def::AbstractProcessDefinition,
+        model_def::AbstractModelDefinition,
+        initPS::AbstractVector{T},
+    ) where {T<:QEDbase.AbstractFourMomentum} end
+
+Interface function for the combination of scattering processes and models. Return the total cross section of a 
+given process and model for a passed initial phase space. The elements of the `AbstractVector` representing the initial phase space
+are the momenta of the respective paricles. The implementation of this function for a concrete process and model must not 
+check if the length of the passed initial phase spaces match number of incoming particles. 
+
+!!! note "cross section interface"
+
+    Given an implementation of this method, the following *unsafe* generic implementation is provided:
+
+    ```julia
+
+    _total_cross_section(proc_def,model_def,initPS::AbstractMatrix{T})
+
+    ```
+
+    where `T<:QEDbase.AbstractFourMomentum`. Although, `_total_cross_section` is also implemented for a vector of initial phase space points.
+    Furthermore, a safe version of `_total_cross_section` is also implemented: [`total_cross_section`](@ref).
+
+
+!!! note 
+    
+    Each instance of this function do not check the validity of the input. 
+    This function is not exported and should be used with caution. To add a method in order to implement the cross section interface, 
+    it is recommented to directly use `QEDprocesses._total_cross_section` instead of globally `using QEDprocesses: _total_cross_section`.
+
+"""
+function _total_cross_section end
+
+function _total_cross_section(
+    proc_def::AbstractProcessDefinition,
+    model_def::AbstractModelDefinition,
+    initPS::AbstractMatrix{T},
+) where {T<:QEDbase.AbstractFourMomentum}
+res = Vector{eltype(initPS[1])}(undef, size(initPS, 2))
+    for i in 1:size(initPS, 2)
+        res[i] = _total_cross_section(proc_def, model_def, view(initPS, :, i))
+    end
+    return res
+end
+
+"""
+
+    total_cross_section(
+        proc_def::AbstractProcessDefinition,
+        model_def::AbstractModelDefinition,
+        initPS::Union{AbstractVector{T},AbstractMatrix{T}},
+    ) where {T<:QEDbase.AbstractFourMomentum}
+
+Return the total cross section for a combination of a scattering process and a compute model evaluated on a given initial phase space. 
+
+This function will eventually call the respective interface function [`_total_cross_section`](@ref).
+
+"""
+function total_cross_section(
+    proc_def::AbstractProcessDefinition,
+    model_def::AbstractModelDefinition,
+    initPS::Union{AbstractVector{T},AbstractMatrix{T}},
+) where {T<:QEDbase.AbstractFourMomentum}
+    size(initPS, 1) == number_incoming_pariticles(proc_def) || throw(
+        DimensionMismatch("The number of momenta in the initial phasespace <{length(initPS)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
+    )
+    return _total_cross_section(proc_def, model_def, initPS)
+end

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -92,7 +92,7 @@ check if the length of the passed phase spaces match the respective number of pa
 
 !!! note "unsafe implementation"
     
-    Each instance of this function do not check the validity of the input. 
+    Each instance of this function does not check the validity of the input. 
     Therefore, these functions are not exported and should be used with caution. To add a method in order to implement the cross section interface, 
     it is recommented to directly use `QEDprocesses._differential_cross_section` instead of globally `using QEDprocesses: _differential_cross_section`.
 

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -124,7 +124,7 @@ function differential_cross_section(
         DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
     )
     size(final_phasespace, 1) == number_outgoing_pariticles(proc_def) || throw(
-        DimensionMismatch("The number of momenta in the final phasespace <{length(final_phasespace)}> does not match the number of incoming particles of the process <{number_outgoing_pariticles(proc_def)}>."),
+        DimensionMismatch("The number of momenta in the final phasespace <{length(final_phasespace)}> does not match the number of outgoing particles of the process <{number_outgoing_pariticles(proc_def)}>."),
     )
     return _differential_cross_section(proc_def, model_def, init_phasespace, final_phasespace)
 end

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -12,7 +12,7 @@
     AbstractParticleType <: AbstractParticle
 
 This is the abstract base type for every species of particles. All functionalities defined on subtypes of `AbstractParticleType` should be static, i.e. known at compile time. 
-For adding runtime information, e.g. four-momenta or particle states, to a particle, consider implementing a concrete subtype of `AbstractParticle` instead, which may have a type parameter `P<:AbstractParticleType`. See the concrete type `Particle{P,ST,MT}`
+For adding runtime information, e.g. four-momenta or particle states, to a particle, consider implementing concrete subtype of `AbstractParticle` instead, which may has a type parameter `P<:AbstractParticleType`. See the concrete type `Particle{P,ST,MT}`
 
 Concrete built-in subtypes of `AbstractParticleType` are 
 

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -12,7 +12,7 @@
     AbstractParticleType <: AbstractParticle
 
 This is the abstract base type for every species of particles. All functionalities defined on subtypes of `AbstractParticleType` should be static, i.e. known at compile time. 
-For adding runtime information, e.g. four-momenta or particle states, to a particle, consider implementing concrete subtype of `AbstractParticle` instead, which may has a type parameter `P<:AbstractParticleType`. See the concrete type `Particle{P,ST,MT}`
+For adding runtime information, e.g. four-momenta or particle states, to a particle, consider implementing a concrete subtype of `AbstractParticle` instead, which may have a type parameter `P<:AbstractParticleType`. See the concrete type `Particle{P,ST,MT}`
 
 Concrete built-in subtypes of `AbstractParticleType` are 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,29 @@
+###########
+# utility functions
+#
+# This file contains small helper and utility functions used throughout the package.
+#
+# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
+# ecosystem.
+###############
+
+
+"""
+
+    _base_component_type(array_of_lv::AbstractArray{LV}) where {LV<:QEDbase.AbstractLorentzVector}
+
+Return the type of the components of given Lorentz vectors, which are by themself elements of an 
+`AbstractArray`.
+
+# Examples
+```julia
+julia> using QEDbase
+julia> using QEDprocesses
+julia> v = Vector{SFourMomentum}(undef,10)
+julia> QEDprocesses._base_component_type(v)
+Float64
+```
+"""
+function _base_component_type(::AbstractArray{LV}) where {LV<:QEDbase.AbstractLorentzVector}
+    return eltype(LV)
+end

--- a/test/Manifest.toml
+++ b/test/Manifest.toml
@@ -2,25 +2,165 @@
 
 julia_version = "1.8.5"
 manifest_format = "2.0"
-project_hash = "84ac8e29f8ef0077a3683e8c5d2cbbf44f698527"
+project_hash = "f84a515d3aac98fb997a427180505537ae56db1a"
+
+[[deps.ArgCheck]]
+git-tree-sha1 = "a3a402a35a2f7e0b87828ccabbd5ebfbebe356b4"
+uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+version = "2.3.0"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.Calculus]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
+uuid = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
+version = "0.5.1"
+
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "e30f2f4e20f7f186dc36529910beaedc60cfa644"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.16.0"
+
+[[deps.CommonSolve]]
+git-tree-sha1 = "0eee5eb66b1cf62cd6ad1b460238e60e4b09400c"
+uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+version = "0.2.4"
+
+[[deps.Compat]]
+deps = ["Dates", "LinearAlgebra", "UUIDs"]
+git-tree-sha1 = "e460f044ca8b99be31d35fe54fc33a5c33dd8ed7"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.9.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.0.1+0"
+
+[[deps.ConstructionBase]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "c53fc348ca4d40d7b371e71fd52251839080cbc9"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.5.4"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.6"
+
+[[deps.Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[deps.InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "68772f49f54b479fa88ace904f6127f0a3bb2e46"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.12"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "9ee1618cbf5240e6d4e0371d6f24065083f60c48"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.11"
 
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[deps.Measurements]]
+deps = ["Calculus", "LinearAlgebra", "Printf", "RecipesBase", "Requires"]
+git-tree-sha1 = "51d946d38d62709d6a2d37ea9bcc30c80c686801"
+uuid = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+version = "2.9.0"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.20+0"
+
+[[deps.PhysicalConstants]]
+deps = ["Measurements", "Roots", "Unitful"]
+git-tree-sha1 = "cd4da9d1890bc2204b08fe95ebafa55e9366ae4e"
+uuid = "5ad8b20f-a522-5ce9-bfc9-ddf1d5bda6ab"
+version = "0.2.3"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.0"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "7eb1686b4f04b82f96ed7a4ea5890a4f0c7a09f1"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.0"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.QEDbase]]
+deps = ["ArgCheck", "ConstructionBase", "DocStringExtensions", "LinearAlgebra", "PhysicalConstants", "Random", "SimpleTraits", "StaticArrays"]
+git-tree-sha1 = "d8869c0f04734347f3f906e0498f25dc223a054c"
+uuid = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
+version = "0.1.4"
+
 [[deps.Random]]
 deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.RecipesBase]]
+deps = ["PrecompileTools"]
+git-tree-sha1 = "5c3d09cc4f31f5fc6af001c250bf1278733100ff"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.3.4"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
+
+[[deps.Roots]]
+deps = ["ChainRulesCore", "CommonSolve", "Printf", "Setfield"]
+git-tree-sha1 = "ff42754a57bb0d6dcfe302fd0d4272853190421f"
+uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+version = "2.0.19"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -34,6 +174,60 @@ version = "0.1.0"
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
+[[deps.Setfield]]
+deps = ["ConstructionBase", "Future", "MacroTools", "StaticArraysCore"]
+git-tree-sha1 = "e2cc6d8c88613c05e1defb55170bf5ff211fbeac"
+uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+version = "1.1.1"
+
+[[deps.SimpleTraits]]
+deps = ["InteractiveUtils", "MacroTools"]
+git-tree-sha1 = "5d7e3f4e11935503d3ecaf7186eac40602e7d231"
+uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+version = "0.9.4"
+
+[[deps.SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
+git-tree-sha1 = "51621cca8651d9e334a659443a74ce50a3b6dfab"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.6.3"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "36b3d696ce6366023a0ea192b4cd442268995a0d"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.2"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.0"
+
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.Unitful]]
+deps = ["ConstructionBase", "Dates", "InverseFunctions", "LinearAlgebra", "Random"]
+git-tree-sha1 = "a72d22c7e13fe2de562feda8645aa134712a87ee"
+uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
+version = "1.17.0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.1.1+0"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,5 @@
 [deps]
+QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/interfaces/model_interface.jl
+++ b/test/interfaces/model_interface.jl
@@ -1,0 +1,14 @@
+using QEDprocesses
+
+struct TestModel <: AbstractModelDefinition end
+fundamental_interaction_type(::TestModel) = :test_interaction
+
+struct TestModel_FAIL <: AbstractModelDefinition end
+
+@testset "hard interface" begin
+    @test fundamental_interaction_type(TestModel()) == :test_interaction
+end
+
+@testset "interface fail" begin
+    @test_throws MethodError fundamental_interaction_type(TestModel_FAIL())
+end

--- a/test/interfaces/particle_interface.jl
+++ b/test/interfaces/particle_interface.jl
@@ -1,9 +1,17 @@
 
-
+using Random
 using QEDprocesses
 
+RNG = MersenneTwister(137137137)
+
+RND_MASS = rand(RNG)
+RND_CHARGE = rand(RNG)
+
+struct TestParticle <: AbstractParticle end
+QEDprocesses.mass(::TestParticle) = RND_MASS 
+QEDprocesses.charge(::TestParticle) = RND_CHARGE
+
 @testset "default interface" begin
-    struct TestParticle <: AbstractParticle end
     @test !is_fermion(TestParticle())
     @test !is_boson(TestParticle())
     @test is_particle(TestParticle())
@@ -11,7 +19,12 @@ using QEDprocesses
 end
 
 @testset "hard interface" begin
-    struct TestParticle <: AbstractParticle end
-    @test_throws Exception charge(TestParticle())
-    @test_throws Exception mass(TestParticle())
+    @test mass(TestParticle()) == RND_MASS
+    @test charge(TestParticle()) == RND_CHARGE
+end
+
+struct TestParticle_FAIL <: AbstractParticle end
+@testset "interface fail" begin
+    @test_throws MethodError charge(TestParticle_FAIL())
+    @test_throws MethodError mass(TestParticle_FAIL())
 end

--- a/test/interfaces/process_interface.jl
+++ b/test/interfaces/process_interface.jl
@@ -44,7 +44,7 @@ _groundtruth_finalCS(initPS) = _groundtruth_diffCS(initPS,initPS)
     @test_throws MethodError incoming_particles(TestProcess_FAIL())
     @test_throws MethodError outgoing_particles(TestProcess_FAIL())
 end
-@testset "($N_INCOMING,N_OUTGOING)" for (N_INCOMING,N_OUTGOING) in Iterators.product(
+@testset "($N_INCOMING,$N_OUTGOING)" for (N_INCOMING,N_OUTGOING) in Iterators.product(
                                                                                      (1, rand(RNG, 2:8)), (1, rand(RNG, 2:8))
                                                                                     )   
 

--- a/test/interfaces/process_interface.jl
+++ b/test/interfaces/process_interface.jl
@@ -93,7 +93,7 @@ end
                 TestProcess(), TestModel(), p_in, p_out
             )
 
-            groundtruth = Vector{Float64}(undef, size(p_out, 2))
+            groundtruth = Vector{QEDprocesses._base_component_type(p_in)}(undef, size(p_out, 2))
             for i in 1:size(p_out, 2)
                 groundtruth[i] = _groundtruth_diffCS(p_in, view(p_out, :, i))
             end
@@ -104,7 +104,7 @@ end
             p_in = _rand_momenta(RNG,N_INCOMING,2) 
             p_out = _rand_momenta(RNG,N_OUTGOING) 
             diffCS = differential_cross_section(TestProcess(), TestModel(), p_in, p_out)
-            groundtruth = Vector{Float64}(undef, size(p_in, 2))
+            groundtruth = Vector{QEDprocesses._base_component_type(p_in)}(undef, size(p_in, 2))
             for i in 1:size(p_in, 2)
                 groundtruth[i] = _groundtruth_diffCS(view(p_in, :, i), p_out)
             end
@@ -115,7 +115,7 @@ end
             p_in = _rand_momenta(RNG,N_INCOMING,2) 
             p_out = _rand_momenta(RNG,N_OUTGOING,2)
             diffCS = differential_cross_section(TestProcess(), TestModel(), p_in, p_out)
-            groundtruth = Matrix{Float64}(undef, size(p_in, 2), size(p_out, 2))
+            groundtruth = Matrix{QEDprocesses._base_component_type(p_in)}(undef, size(p_in, 2), size(p_out, 2))
             for i in 1:size(p_in, 2)
                 for j in 1:size(p_out, 2)
                     groundtruth[i, j] = _groundtruth_diffCS(

--- a/test/interfaces/process_interface.jl
+++ b/test/interfaces/process_interface.jl
@@ -1,0 +1,158 @@
+using Random
+using QEDbase
+using QEDprocesses
+
+RNG = MersenneTwister(137137)
+ATOL = 0.0
+RTOL = sqrt(eps())
+
+function _rand_momenta(rng::AbstractRNG,N)
+    moms = Vector{SFourMomentum}(undef,N)
+    for i in 1:N 
+        moms[i] = SFourMomentum(rand(rng,4))
+    end
+    return moms
+end
+
+function _rand_momenta(rng::AbstractRNG,N1,N2)
+    moms = Matrix{SFourMomentum}(undef,N1,N2)
+    for i in 1:N1 
+        for j in 1:N2
+            moms[i,j] = SFourMomentum(rand(rng,4))
+        end
+    end
+    return moms
+end
+
+struct TestParticle1 <: AbstractParticle end
+struct TestParticle2 <: AbstractParticle end
+struct TestParticle3 <: AbstractParticle end
+struct TestParticle4 <: AbstractParticle end
+
+PARTICLE_SET = [TestParticle1(), TestParticle2(), TestParticle3(),TestParticle4()]
+
+struct TestProcess <: AbstractProcessDefinition end
+struct TestProcess_FAIL <: AbstractProcessDefinition end
+
+struct TestModel <: AbstractModelDefinition end
+struct TestModel_FAIL <: AbstractModelDefinition end
+
+_groundtruth_diffCS(initPS,finalPS) = sum(initPS)*sum(finalPS)
+_groundtruth_finalCS(initPS) = _groundtruth_diffCS(initPS,initPS)
+
+@testset "interface fail" begin
+    @test_throws MethodError incoming_particles(TestProcess_FAIL())
+    @test_throws MethodError outgoing_particles(TestProcess_FAIL())
+end
+@testset "($N_INCOMING,N_OUTGOING)" for (N_INCOMING,N_OUTGOING) in Iterators.product(
+                                                                                     (1, rand(RNG, 2:8)), (1, rand(RNG, 2:8))
+                                                                                    )   
+
+    INCOMING_PARTICLES = rand(RNG,PARTICLE_SET,N_INCOMING)
+    OUTGOING_PARTICLES = rand(RNG,PARTICLE_SET,N_OUTGOING)
+
+    QEDprocesses.incoming_particles(::TestProcess) = INCOMING_PARTICLES
+    QEDprocesses.outgoing_particles(::TestProcess) = OUTGOING_PARTICLES 
+
+    function QEDprocesses._differential_cross_section(proc::TestProcess,model::TestModel,initPS::AbstractVector{T},finalPS::AbstractVector{T}) where {T<:QEDbase.AbstractFourMomentum}
+        _groundtruth_diffCS(initPS,finalPS)
+    end
+
+    function QEDprocesses._total_cross_section(proc::TestProcess,model::TestModel,initPS::AbstractVector{T}) where {T<:QEDbase.AbstractFourMomentum}
+        _groundtruth_finalCS(initPS)
+    end
+
+    @testset "hard interface" begin
+        @test incoming_particles(TestProcess()) == INCOMING_PARTICLES 
+        @test outgoing_particles(TestProcess()) == OUTGOING_PARTICLES 
+    end
+
+
+    @testset "differential cross section" begin
+
+        @testset "interface fail" begin
+            p_in = _rand_momenta(RNG,N_INCOMING) 
+            p_out = _rand_momenta(RNG,N_OUTGOING) 
+
+            @test_throws MethodError differential_cross_section(TestProcess(),TestModel_FAIL(),p_in,p_out)
+            @test_throws MethodError total_cross_section(TestProcess(),TestModel_FAIL(),p_in,p_out)
+        end
+
+        @testset "compute vector-vector" begin
+            p_in = _rand_momenta(RNG,N_INCOMING) 
+            p_out = _rand_momenta(RNG,N_OUTGOING) 
+            diffCS = differential_cross_section(TestProcess(), TestModel(), p_in, p_out)
+            groundtruth = _groundtruth_diffCS(p_in, p_out)
+            @test isapprox(diffCS, groundtruth, atol=ATOL, rtol=RTOL)
+        end
+
+        @testset "compute vector-matrix" begin
+            p_in = _rand_momenta(RNG,N_INCOMING) 
+            p_out = _rand_momenta(RNG,N_OUTGOING,2) 
+            diffCS = differential_cross_section(
+                TestProcess(), TestModel(), p_in, p_out
+            )
+
+            groundtruth = Vector{Float64}(undef, size(p_out, 2))
+            for i in 1:size(p_out, 2)
+                groundtruth[i] = _groundtruth_diffCS(p_in, view(p_out, :, i))
+            end
+            @test isapprox(diffCS, groundtruth, atol=ATOL, rtol=RTOL)
+        end
+
+        @testset "compute matrix-vector" begin
+            p_in = _rand_momenta(RNG,N_INCOMING,2) 
+            p_out = _rand_momenta(RNG,N_OUTGOING) 
+            diffCS = differential_cross_section(TestProcess(), TestModel(), p_in, p_out)
+            groundtruth = Vector{Float64}(undef, size(p_in, 2))
+            for i in 1:size(p_in, 2)
+                groundtruth[i] = _groundtruth_diffCS(view(p_in, :, i), p_out)
+            end
+            @test isapprox(diffCS, groundtruth, atol=ATOL, rtol=RTOL)
+        end
+
+        @testset "compute matrix-matrix" begin
+            p_in = _rand_momenta(RNG,N_INCOMING,2) 
+            p_out = _rand_momenta(RNG,N_OUTGOING,2)
+            diffCS = differential_cross_section(TestProcess(), TestModel(), p_in, p_out)
+            groundtruth = Matrix{Float64}(undef, size(p_in, 2), size(p_out, 2))
+            for i in 1:size(p_in, 2)
+                for j in 1:size(p_out, 2)
+                    groundtruth[i, j] = _groundtruth_diffCS(
+                        view(p_in, :, i), view(p_out, :, j)
+                    )
+                end
+            end
+            @test isapprox(diffCS, groundtruth, atol=ATOL, rtol=RTOL)
+        end
+        
+        @testset "fail vector-vector" begin
+            p_in = _rand_momenta(RNG,N_INCOMING) 
+            p_out = _rand_momenta(RNG,N_OUTGOING) 
+            @test_throws DimensionMismatch differential_cross_section(TestProcess(), TestModel(), _rand_momenta(RNG,N_INCOMING+1), p_out)
+            @test_throws DimensionMismatch differential_cross_section(TestProcess(), TestModel(), p_in, _rand_momenta(RNG,N_OUTGOING+1))
+        end
+
+        @testset "fail vector-matrix" begin
+            p_in = _rand_momenta(RNG,N_INCOMING) 
+            p_out = _rand_momenta(RNG,N_OUTGOING,2) 
+            @test_throws DimensionMismatch differential_cross_section(TestProcess(), TestModel(), _rand_momenta(RNG,N_INCOMING+1), p_out)
+            @test_throws DimensionMismatch differential_cross_section(TestProcess(), TestModel(), p_in, _rand_momenta(RNG,N_OUTGOING+1,2))
+        end
+
+        @testset "fail matrix-vector" begin
+            p_in = _rand_momenta(RNG,N_INCOMING,2) 
+            p_out = _rand_momenta(RNG,N_OUTGOING) 
+            @test_throws DimensionMismatch differential_cross_section(TestProcess(), TestModel(), _rand_momenta(RNG,N_INCOMING+1,2), p_out)
+            @test_throws DimensionMismatch differential_cross_section(TestProcess(), TestModel(), p_in, _rand_momenta(RNG,N_OUTGOING+1))
+        end
+
+        @testset "fail matrix-matrix" begin
+            p_in = _rand_momenta(RNG,N_INCOMING,2) 
+            p_out = _rand_momenta(RNG,N_OUTGOING,2)
+            @test_throws DimensionMismatch differential_cross_section(TestProcess(), TestModel(), _rand_momenta(RNG,N_INCOMING+1,2),p_out)
+            @test_throws DimensionMismatch differential_cross_section(TestProcess(), TestModel(), p_in, _rand_momenta(RNG,N_OUTGOING+1,2))
+        end
+    end
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using SafeTestsets
 begin
     # Interfaces
     @time @safetestset "particle interface" begin include("interfaces/particle_interface.jl") end
+    @time @safetestset "model interface" begin include("interfaces/model_interface.jl") end
+    @time @safetestset "process interface" begin include("interfaces/process_interface.jl") end
 
     # modules
     @time @safetestset "particles types" begin include("particle_types.jl") end


### PR DESCRIPTION

This PR provides an implementation of the model and process interface, which is also combined with an interface for differential and total cross-sections. 

# The model definition interface

In this PR, the model interface describes only static information, i.e. there is only one un-parameterized base type and a convenient interface function:

```julia
AbstractModelDefinition
fundamental_interaction_type(::AbstractModelDefiniton)
```

# The process definition interface

In this PR, the process interface describes only static information about a scattering process. Here, a scattering process should be seen in a generic way, which forms a physical scattering process, if it is combined with a model definition above. 

The process definition interface is defined as 
```julia 
AbstractProcessDefinition     #base type for processes
incoming_particles(::AbstractProcessDefinition) # return tuple of incoming particle-like  
outgoing_particles(::AbstractProcessDefinition) # return tuple of outgoing particle-like 
```
Here, *particle-like* stands for subtypes of `AbstractParticleType`, so the static instances of particles.

Additionally, in this PR, the following process related functions are implemented

```julia
number_incoming_particles(::AbstractProcessDefinition) # number of incoming particles-like
number_outgoing_particles(::AbstractProcessDefinition) # number of outgoing particles-like
```

# Cross sections
Based in the interface funcitons for process and model definition, this PR also provides an interface for differential and total cross sections. This interface is definied my the following two functions:

```julia
    _differential_cross_section(
        proc_def::AbstractProcessDefinition,
        model_def::AbstractModelDefinition,
        initPS::AbstractVector{T},
        finalPS::AbstractVector{T},
    ) where {T<:QEDbase.AbstractFourMomentum}

    _total_cross_section(
        proc_def::AbstractProcessDefinition,
        model_def::AbstractModelDefinition,
        initPS::AbstractVector{T},
    ) where {T<:QEDbase.AbstractFourMomentum} end
```

where `initPS` and `finalPS` are vectors containing the four-momenta of the incoming and outgoing particles, respectively. The leading `_` indicates, that the functions are not exported, and that no input-validation is applied. Additionally, there are versions of `_differential_cross_section` and `_total_cross_section`, which evaluate the respective quantity on a set of phase space points, i.e. a matrix of four-momenta, where the columns represent the momenta of the incoming or outgoing particles and the rows represent the different phase space points. Currently, only serial execution of the respective loops is implemented. 

# Testing

The unit-tests for the interface have the following structure:

* a full test implementation of every interface
* a partitial test implementation of every interface (dedicated for failing the interface, the are indicated by an appended `_FAIL`)
* a test for every interface function
* a test for every derived function
* a test for every break of the interface

# Final remarks
The `README.md` is updated to include a small section on how-to build the documentation locally. 

