### PR TITLE
Computation and process setup interface

### DIFF
--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -14,7 +14,7 @@ export number_incoming_particles, number_outgoing_particles
 export differential_cross_section, total_cross_section
 
 # Abstract setup interface
-export AbstractComputationSetup, compute
+export AbstractComputationSetup, InvalidInputError, compute
 export AbstractProcessSetup, scattering_process, compute_model 
 
 # particle types

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -13,6 +13,10 @@ export initial_phasespace_dimension, final_phasespace_dimension
 export number_incoming_particles, number_outgoing_particles
 export differential_cross_section, total_cross_section
 
+# Abstract setup interface
+export AbstractComputationSetup, compute
+export AbstractProcessSetup, scattering_process, compute_model 
+
 # particle types
 export AbstractParticleType
 export FermionLike, Fermion, AntiFermion, MajoranaFermion
@@ -26,5 +30,6 @@ include("utils.jl")
 include("interfaces/particle_interface.jl")
 include("interfaces/model_interface.jl")
 include("interfaces/process_interface.jl")
+include("interfaces/setup_interface.jl")
 include("particle_types.jl")
 end

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -15,7 +15,7 @@ export differential_cross_section, total_cross_section
 
 # Abstract setup interface
 export AbstractComputationSetup, InvalidInputError, compute
-export AbstractProcessSetup, scattering_process, physical_model 
+export AbstractProcessSetup, scattering_process, physical_model
 
 # particle types
 export AbstractParticleType

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -15,7 +15,7 @@ export differential_cross_section, total_cross_section
 
 # Abstract setup interface
 export AbstractComputationSetup, InvalidInputError, compute
-export AbstractProcessSetup, scattering_process, compute_model 
+export AbstractProcessSetup, scattering_process, physical_model 
 
 # particle types
 export AbstractParticleType

--- a/src/interfaces/model_interface.jl
+++ b/src/interfaces/model_interface.jl
@@ -3,10 +3,6 @@
 #
 # In this file, we define the interface of working with compute models in
 # general.
-# 
-# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
-# ecosystem.
-#
 ###############
 # root type for models
 """

--- a/src/interfaces/particle_interface.jl
+++ b/src/interfaces/particle_interface.jl
@@ -3,10 +3,6 @@
 #
 # In this file, we define the interface for working with particles in a general
 # sense. 
-# 
-# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
-# ecosystem.
-#
 ###############
 
 

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -121,10 +121,10 @@ function differential_cross_section(
     final_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
     ) where {T<:QEDbase.AbstractFourMomentum}
     size(init_phasespace, 1) == number_incoming_particles(proc_def) || throw(
-        DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
+        DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_particles(proc_def)}>."),
     )
     size(final_phasespace, 1) == number_outgoing_particles(proc_def) || throw(
-        DimensionMismatch("The number of momenta in the final phasespace <{length(final_phasespace)}> does not match the number of outgoing particles of the process <{number_outgoing_pariticles(proc_def)}>."),
+        DimensionMismatch("The number of momenta in the final phasespace <{length(final_phasespace)}> does not match the number of outgoing particles of the process <{number_outgoing_particles(proc_def)}>."),
     )
     return _differential_cross_section(proc_def, model_def, init_phasespace, final_phasespace)
 end
@@ -257,7 +257,7 @@ function total_cross_section(
     init_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
 ) where {T<:QEDbase.AbstractFourMomentum}
     size(init_phasespace, 1) == number_incoming_particles(proc_def) || throw(
-        DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
+        DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_particles(proc_def)}>."),
     )
     return _total_cross_section(proc_def, model_def, init_phasespace)
 end

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -115,14 +115,23 @@ function differential_cross_section(
     model_def::AbstractModelDefinition,
     init_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
     final_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
-    ) where {T<:QEDbase.AbstractFourMomentum}
+) where {T<:QEDbase.AbstractFourMomentum}
     size(init_phasespace, 1) == number_incoming_particles(proc_def) || throw(
-        DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_particles(proc_def)}>."),
+        DimensionMismatch(
+            "The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_particles(proc_def)}>.",
+        ),
     )
     size(final_phasespace, 1) == number_outgoing_particles(proc_def) || throw(
-        DimensionMismatch("The number of momenta in the final phasespace <{length(final_phasespace)}> does not match the number of outgoing particles of the process <{number_outgoing_particles(proc_def)}>."),
+        DimensionMismatch(
+            "The number of momenta in the final phasespace <{length(final_phasespace)}> does not match the number of outgoing particles of the process <{number_outgoing_particles(proc_def)}>.",
+        ),
     )
-    return _differential_cross_section(proc_def, model_def, init_phasespace, final_phasespace)
+    return _differential_cross_section(
+        proc_def,
+        model_def,
+        init_phasespace,
+        final_phasespace,
+    )
 end
 
 # returns diffCS for single `initPS` and several `finalPS` points without input-check
@@ -253,7 +262,9 @@ function total_cross_section(
     init_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
 ) where {T<:QEDbase.AbstractFourMomentum}
     size(init_phasespace, 1) == number_incoming_particles(proc_def) || throw(
-        DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_particles(proc_def)}>."),
+        DimensionMismatch(
+            "The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_particles(proc_def)}>.",
+        ),
     )
     return _total_cross_section(proc_def, model_def, init_phasespace)
 end

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -47,7 +47,7 @@ function outgoing_particles end
 
 Return the number of incoming particles of a given process. 
 """
-@inline function number_incoming_pariticles(proc_def::AbstractProcessDefinition)
+@inline function number_incoming_particles(proc_def::AbstractProcessDefinition)
     return length(incoming_particles(proc_def))
 end
 
@@ -57,7 +57,7 @@ end
 
 Return the number of outgoing particles of a given process. 
 """
-@inline function number_outgoing_pariticles(proc_def::AbstractProcessDefinition)
+@inline function number_outgoing_particles(proc_def::AbstractProcessDefinition)
     return length(outgoing_particles(proc_def))
 end
 
@@ -119,23 +119,14 @@ function differential_cross_section(
     model_def::AbstractModelDefinition,
     init_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
     final_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
-) where {T<:QEDbase.AbstractFourMomentum}
-    size(init_phasespace, 1) == number_incoming_pariticles(proc_def) || throw(
-        DimensionMismatch(
-            "The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>.",
-        ),
+    ) where {T<:QEDbase.AbstractFourMomentum}
+    size(init_phasespace, 1) == number_incoming_particles(proc_def) || throw(
+        DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
     )
-    size(final_phasespace, 1) == number_outgoing_pariticles(proc_def) || throw(
-        DimensionMismatch(
-            "The number of momenta in the final phasespace <{length(final_phasespace)}> does not match the number of outgoing particles of the process <{number_outgoing_pariticles(proc_def)}>.",
-        ),
+    size(final_phasespace, 1) == number_outgoing_particles(proc_def) || throw(
+        DimensionMismatch("The number of momenta in the final phasespace <{length(final_phasespace)}> does not match the number of outgoing particles of the process <{number_outgoing_pariticles(proc_def)}>."),
     )
-    return _differential_cross_section(
-        proc_def,
-        model_def,
-        init_phasespace,
-        final_phasespace,
-    )
+    return _differential_cross_section(proc_def, model_def, init_phasespace, final_phasespace)
 end
 
 # returns diffCS for single `initPS` and several `finalPS` points without input-check
@@ -265,10 +256,8 @@ function total_cross_section(
     model_def::AbstractModelDefinition,
     init_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
 ) where {T<:QEDbase.AbstractFourMomentum}
-    size(init_phasespace, 1) == number_incoming_pariticles(proc_def) || throw(
-        DimensionMismatch(
-            "The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>.",
-        ),
+    size(init_phasespace, 1) == number_incoming_particles(proc_def) || throw(
+        DimensionMismatch("The number of momenta in the initial phasespace <{length(init_phasespace)}> does not match the number of incoming particles of the process <{number_incoming_pariticles(proc_def)}>."),
     )
     return _total_cross_section(proc_def, model_def, init_phasespace)
 end

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -3,10 +3,6 @@
 #
 # In this file, we define the interface for working with scattering processes in
 # general.
-# 
-# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
-# ecosystem.
-#
 ###############
 
 """

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -66,8 +66,8 @@ end
         final_phasespace::AbstractVector{T},
     ) where {T<:QEDbase.AbstractFourMomentum}
 
-Interface function for the combination of scattering processes and models. Return the differential cross section of a 
-given process and model for a passed initial and final phase space. The elements of the `AbstractVector` representing the phase spaces 
+Interface function for the combination of scattering processes and physical models. Return the differential cross section of a 
+given process and physical model for a passed initial and final phase space. The elements of the `AbstractVector` representing the phase spaces 
 are the momenta of the respective particles. The implementation of this function for a concrete process and model must not 
 check if the length of the passed phase spaces match the respective number of particles. 
 
@@ -194,7 +194,7 @@ end
         init_phasespace::AbstractVector{T},
     ) where {T<:QEDbase.AbstractFourMomentum} end
 
-Interface function for the combination of scattering processes and models. Return the total cross section of a 
+Interface function for the combination of scattering processes and physical models. Return the total cross section of a 
 given process and model for a passed initial phase space. The elements of the `AbstractVector` representing the initial phase space
 are the momenta of the respective particles. The implementation of this function for a concrete process and model must not 
 check if the length of the passed initial phase spaces match number of incoming particles. 
@@ -242,7 +242,7 @@ end
         init_phasespace::Union{AbstractVector{T},AbstractMatrix{T}},
     ) where {T<:QEDbase.AbstractFourMomentum}
 
-Return the total cross section for a combination of a scattering process and a compute model evaluated on a given initial phase space. 
+Return the total cross section for a combination of a scattering process and a physical model evaluated on a given initial phase space. 
 
 This function will eventually call the respective interface function [`_total_cross_section`](@ref).
 

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -44,15 +44,15 @@ quantity depends on is kept constant.
     which computes the value of the associated quantity for a given `input` (see [`_compute`](@ref) for more details).
 
 
-    ## Post computation
+    ## Post processing 
 
     Every subtype of `AbstractComputationSetup` should implement the interface function
     
     ```Julia
-    _post_computation(stp::AbstractComputationSetup, input) 
+    _post_processing(stp::AbstractComputationSetup, input, result) 
     ```
     
-    which performs *computations* after the actual computation, e.g. conversions or normalizations (see [`_post_computation`](@ref) for more details).
+    which performs task after the actual computation, e.g. conversions or normalizations (see [`_post_processing`](@ref) for more details).
 
 
     
@@ -120,17 +120,17 @@ end
 
 """
     
-    function _post_computation(stp::AbstractComputationSetup, input::Any, result::Any)
+    function _post_processing(stp::AbstractComputationSetup, input::Any, result::Any)
     
 Interface function, which is called in [`compute`](@ref) after [`_compute`](@ref) has been called. This function is dedicated to 
 finalize the result of a computation. 
 
 !!! note "default implementation"
 
-    Since in the case of no post computation the result of [`_compute`](@ref) is unchanged, this function returns `result` by default.
+    Since in the case of no post processing the result of [`_compute`](@ref) is unchanged, this function returns `result` by default.
 
 """
-@inline function _post_computation(stp::AbstractComputationSetup, input, result)
+@inline function _post_processing(stp::AbstractComputationSetup, input, result)
     return result
 end
 
@@ -142,7 +142,7 @@ Interface function that returns the value of the associated quantity evaluated o
 
 !!! note "unsafe implementation"
 
-    This function must be implemented for any subtype of [`AbstractComputationSetup`]. It should not do any input validation or post processing (see [`_is_valid_input`](@ref) and [`_post_computation`](@ref)), as those two are performed while calling 
+    This function must be implemented for any subtype of [`AbstractComputationSetup`]. It should not do any input validation or post processing (see [`_is_valid_input`](@ref) and [`_post_processing`](@ref)), as those two are performed while calling 
     the safe version of this function [`compute`](@ref).
 
 """
@@ -154,13 +154,13 @@ function _compute end
 
 Return the value of the quantity associated with `stp` for a given `input`. 
 In addition to the actual call of the associated unsafe version [`_compute`](@ref),
-input validation ([`_assert_valid_input`]) and post computation
-(using [`_post_computation`](@ref)) are wrapped around the calculation (see [`AbstractComputationSetup`](@ref) for details).
+input validation ([`_assert_valid_input`]) and post processing 
+(using [`_post_processing`](@ref)) are wrapped around the calculation (see [`AbstractComputationSetup`](@ref) for details).
 """
 function compute(stp::AbstractComputationSetup, input)
     _assert_valid_input(stp,input) 
     raw_result = _compute(stp,input)
-    return _post_computation(stp, input,raw_result)
+    return _post_processing(stp, input,raw_result)
 end
 
 """

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -78,10 +78,11 @@ abstract type AbstractInvalidInputException <: Exception end
 
 Exception which is thrown if a given input is invalid, e.g. passed to [`_assert_valid_input`](@ref).
 """
-struct InvalidInputError <: AbstractInvalidInputException 
+struct InvalidInputError <: AbstractInvalidInputException
     msg::String
 end
-Base.showerror(io::IO, err::InvalidInputError) = println(io, "InvalidInputError: $(err.msg).")
+Base.showerror(io::IO, err::InvalidInputError) =
+    println(io, "InvalidInputError: $(err.msg).")
 
 """
 
@@ -103,7 +104,7 @@ Interface function, which asserts that the given `input` is valid, and throws an
     Despite the presence of a custom `_assert_valid_input`, it is highly recommended to also implement `_is_valid_input` for `CustomSetup`, because it might be used outside of the assert function.
 
 """
-@inline function _assert_valid_input(stp::AbstractComputationSetup,input)
+@inline function _assert_valid_input(stp::AbstractComputationSetup, input)
     return nothing
 end
 
@@ -125,7 +126,7 @@ An assert version of this function is given by [`_assert_valid_input`](@ref), wh
 """
 @inline function _is_valid_input(stp::AbstractComputationSetup, input)
     try
-        _assert_valid_input(stp,input)
+        _assert_valid_input(stp, input)
     catch e
         if isa(e, AbstractInvalidInputException)
             return false
@@ -176,9 +177,9 @@ input validation ([`_assert_valid_input`]) and post processing
 (using [`_post_processing`](@ref)) are wrapped around the calculation (see [`AbstractComputationSetup`](@ref) for details).
 """
 function compute(stp::AbstractComputationSetup, input)
-    _assert_valid_input(stp,input) 
-    raw_result = _compute(stp,input)
-    return _post_processing(stp, input,raw_result)
+    _assert_valid_input(stp, input)
+    raw_result = _compute(stp, input)
+    return _post_processing(stp, input, raw_result)
 end
 
 """
@@ -219,6 +220,7 @@ an object which is a subtype of [`AbstractModelDefinition`](@ref).
 """
 function physical_model end
 
-@inline number_incoming_particles(stp::AbstractProcessSetup) = number_incoming_particles(scattering_process(stp))
-@inline number_outgoing_particles(stp::AbstractProcessSetup) = number_outgoing_particles(scattering_process(stp))
-
+@inline number_incoming_particles(stp::AbstractProcessSetup) =
+    number_incoming_particles(scattering_process(stp))
+@inline number_outgoing_particles(stp::AbstractProcessSetup) =
+    number_outgoing_particles(scattering_process(stp))

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -30,7 +30,7 @@ quantity depends on is kept constant.
     _assert_valid_input(stp::AbstractComputationSetup, input)
     ```
     
-    which should throw and an exception subtyped from [`AbstractInvalidInputException`](@ref) if the `input` is not valid for the computation of the associated quantity (see [`_is_valid_input`](@ref) and [`_assert_valid_input`](@ref) for more details). 
+    which should throw and an exception subtyped from [`AbstractInvalidInputException`](@ref) if the `input` is not valid for the computation of the associated quantity ([`_assert_valid_input`](@ref) for more details). 
     The default implementation does nothing, i.e. every input is valid by default. Provide a custom implementation if a different behavior is required.
 
     ## Actual computation
@@ -92,49 +92,17 @@ Interface function, which asserts that the given `input` is valid, and throws an
 
 !!! note "default implementation"
 
-    The generic fallback uses the boolian value returned by `_is_valid_input(stp,input)` to check for validity, 
-    i.e. if the returned value is `true` the assert does not trigger and nothing happens, but if the returned value is `false`, 
-    an error with a generic error message will be thrown (see  [`_is_valid_input`](@ref) for details). 
-    To customize the error message, or use a custom assertion mechanism, just add your own implementation of
+    By default, every input is assumed to be valid. Therefore, this functions does nothing. 
+    To customize this behavior add your own implementation of
 
     ```Julia
     _assert_valid_input(stp::YourCustomSetup,input)
     ```
-    which should throw an [`InvalidInputError`](@ref) if the input is invalid.
-    Despite the presence of a custom `_assert_valid_input`, it is highly recommended to also implement `_is_valid_input` for `CustomSetup`, because it might be used outside of the assert function.
+    which should throw an exception, which is subtype of [`AbstractInvalidInputError`](@ref). One may also use the concrete implementation [`InvalidInputError`](@ref) if the input is invalid, instead of writing a custom exception type.
 
 """
 @inline function _assert_valid_input(stp::AbstractComputationSetup, input)
     return nothing
-end
-
-"""
-
-    _is_valid_input(stp::AbstractComputationSetup, input::Any)
-
-Interface function, which returns true if the constraints of the `input` associated with the quantity of `stp` are met.
-This function is called to validate the input of [`compute`](@ref) before calling [`_compute`](@ref).
-
-!!! note "Default implementation"
-    
-    Since no input validation is equivalent to every input being valid, this function returns `true` by default. 
-    This behavior can be overwritten if actual validation is necessary.
-
-
-An assert version of this function is given by [`_assert_valid_input`](@ref), which directly uses the output of this function.
-
-"""
-@inline function _is_valid_input(stp::AbstractComputationSetup, input)
-    try
-        _assert_valid_input(stp, input)
-    catch e
-        if isa(e, AbstractInvalidInputException)
-            return false
-        end
-        @warn "The function _assert_valid_input throws an Exception, which is not an InvalidInputError! The Exception thrown is: "
-        throw(e)
-    end
-    return true
 end
 
 """
@@ -161,7 +129,7 @@ Interface function that returns the value of the associated quantity evaluated o
 
 !!! note "unsafe implementation"
 
-    This function must be implemented for any subtype of [`AbstractComputationSetup`]. It should not do any input validation or post processing (see [`_is_valid_input`](@ref) and [`_post_processing`](@ref)), as those two are performed while calling 
+    This function must be implemented for any subtype of [`AbstractComputationSetup`]. It should not do any input validation or post processing (see [`_assert_valid_input`](@ref) and [`_post_processing`](@ref)), as those two are performed while calling 
     the safe version of this function [`compute`](@ref).
 
 """

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -2,10 +2,6 @@
 # The process setup 
 #
 # In this file, we define the interface for general computation and process setups.
-# 
-# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
-# ecosystem.
-#
 ###############
 
 """

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -27,10 +27,10 @@ quantity depends on is kept constant.
     Every subtype of `AbstractComputationSetup` should implement the interface function
     
     ```Julia
-    _input_validation(stp::AbstractComputationSetup, input) # default: true
+    _is_valid_input(stp::AbstractComputationSetup, input) # default: true
     ```
     
-    which should return true iff the `input` is valid for the computation of the associated quantity (see [`_input_validation`](@ref) for more details). 
+    which should return true iff the `input` is valid for the computation of the associated quantity (see [`_is_valid_input`](@ref) for more details). 
     The default implementation always returns `true`. Provide a custom implementation if a different behavior is required.
 
     ## Actual computation
@@ -75,7 +75,7 @@ This function is called to validate the input of [`compute`](@ref) before callin
     This behavior can be overwritten if actual validation is necessary.
 
 """
-@inline function _input_validation(stp::AbstractComputationSetup, input)
+@inline function _is_valid_input(stp::AbstractComputationSetup, input)
     return true
 end
 
@@ -103,7 +103,7 @@ Interface function that returns the value of the associated quantity evaluated o
 
 !!! note "unsafe implementation"
 
-    This function must be implemented for any subtype of [`AbstractComputationSetup`]. It should not do any input validation or post processing (see [`_input_validation`](@ref) and [`_post_computation`](@ref)), as those two are performed while calling 
+    This function must be implemented for any subtype of [`AbstractComputationSetup`]. It should not do any input validation or post processing (see [`_is_valid_input`](@ref) and [`_post_computation`](@ref)), as those two are performed while calling 
     the safe version of this function [`compute`](@ref).
 
 """
@@ -115,11 +115,11 @@ function _compute end
 
 Return the value of the quantity associated with `stp` for a given `input`. 
 In addition to the actual call of the associated unsafe version [`_compute`](@ref),
-input validation (using [`_input_validation`](@ref)) and post computation
+input validation (using [`_is_valid_input`](@ref)) and post computation
 (using [`_post_computation`](@ref)) are wrapped around the calculation (see [`AbstractComputationSetup`](@ref) for details).
 """
 function compute(stp::AbstractComputationSetup, input)
-    _input_validation(stp,input) || error("InvalidInputError: there is something wrong with the input!\n setup:$stp \n input:$input")
+    _is_valid_input(stp,input) || error("InvalidInputError: there is something wrong with the input!\n setup:$stp \n input:$input")
     raw_result = _compute(stp,input)
     return _post_computation(stp, input,raw_result)
 end

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -16,6 +16,9 @@
 # e.g. QEDbase, therefore it is not exported
 abstract type AbstractComputationSetup end
 
+# convenience function to check if an object is a computation setup
+_is_computation_setup(::AbstractComputationSetup) = true
+
 """
 
     _is_valid_input(stp::AbstractComputationSetup, input::Any)

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -54,8 +54,6 @@ quantity depends on is kept constant.
     
     which performs task after the actual computation, e.g. conversions or normalizations (see [`_post_processing`](@ref) for more details).
 
-
-    
 """
 abstract type AbstractComputationSetup end
 
@@ -164,13 +162,13 @@ function compute(stp::AbstractComputationSetup, input)
 end
 
 """
-Abstract base type for setups related to combining scattering processes and compute models.  
+Abstract base type for setups related to combining scattering processes and physical models.  
 Every subtype of `AbstractProcessSetup` must implement at least the following 
 interface functions:
 
 ```Julia
 scattering_process(::AbstractProcessSetup) 
-compute_model(::AbstractProcessSetup) 
+physical_model(::AbstractProcessSetup) 
 ```
 
 Derived from these interface functions, the following delegations are provided:
@@ -188,18 +186,18 @@ abstract type AbstractProcessSetup <: AbstractComputationSetup end
     scattering_process(stp::AbstractProcessSetup)
 
 Interface function that returns the scattering process associated with `stp`,
-i.e. an object which is a subtype of `AbstractProcessDefinition`. 
+i.e. an object which is a subtype of [`AbstractProcessDefinition`](@ref). 
 """
 function scattering_process end
 
 """
 
-    compute_model(stp::AbstractProcessSetup)
+    physical_model(stp::AbstractProcessSetup)
 
-Interface function that returns the compute model associated with `stp`, i.e.
-an object which is a subtype of `AbstractModelDefinition`.
+Interface function that returns the physical model associated with `stp`, i.e.
+an object which is a subtype of [`AbstractModelDefinition`](@ref).
 """
-function compute_model end
+function physical_model end
 
 @inline number_incoming_particles(stp::AbstractProcessSetup) = number_incoming_particles(scattering_process(stp))
 @inline number_outgoing_particles(stp::AbstractProcessSetup) = number_outgoing_particles(scattering_process(stp))

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -81,12 +81,22 @@ An assert version of this function is given by [`_assert_valid_input`](@ref), wh
 @inline function _is_valid_input(stp::AbstractComputationSetup, input)
     return true
 end
+"""
+
+    InvalidInputError(msg::String)
+
+Exception which is thrown if a given input is invalid, e.g. passed to [`_assert_valid_input`](@ref).
+"""
+struct InvalidInputError <: Exception
+    msg::String
+end
+Base.showerror(io::IO, err::InvalidInputError) = println(io, "InvalidInputError: $(err.msg).")
 
 """
 
     _assert_valid_input(stp::AbstractComputationSetup, input::Any)
 
-Interface function, which asserts that the given `input` is valid, and thows an error if not.
+Interface function, which asserts that the given `input` is valid, and throws an [`InvalidInputError`](@ref) if not.
 
 !!! note "default implementation"
 
@@ -96,13 +106,14 @@ Interface function, which asserts that the given `input` is valid, and thows an 
     To customize the error message, or use a custom assertion mechanism, just add your own implementation of
 
     ```Julia
-    _assert_valid_input(stp::YourCustomSetup,input)        
+    _assert_valid_input(stp::YourCustomSetup,input)
     ```
-    However, it is highly recommented to also implement `_is_valid_input` for `CustomSetup`, because it might be used outside this assert function.
+    which should throw an [`InvalidInputError`](@ref) if the input is invalid.
+    Dispite the presence of a custom `_assert_valid_input`, it is highly recommented to also implement `_is_valid_input` for `CustomSetup`, because it might be used outside the assert function.
 
 """
 @inline function _assert_valid_input(stp::AbstractComputationSetup,input)
-    _is_valid_input(stp,input) || error("InvalidInputError: there is something wrong with the input!\n setup:$stp \n input:$input")
+    _is_valid_input(stp,input) || throw(InvalidInputError("Something wrong with the input!\n setup:$stp \n input:$input"))
 
     return nothing
 end

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -30,7 +30,7 @@ quantity depends on is kept constant.
     _assert_valid_input(stp::AbstractComputationSetup, input)
     ```
     
-    which should throw and an exception subtyped from [`AbstractInvalidInputException`](@ref) if the `input` is not valid for the computation of the associated quantity ([`_assert_valid_input`](@ref) for more details). 
+    which should throw and an exception subtyped from [`AbstractInvalidInputException`](@ref) if the `input` is not valid for the computation of the associated quantity (see [`_assert_valid_input`](@ref) for more details). 
     The default implementation does nothing, i.e. every input is valid by default. Provide a custom implementation if a different behavior is required.
 
     ## Actual computation
@@ -92,13 +92,13 @@ Interface function, which asserts that the given `input` is valid, and throws an
 
 !!! note "default implementation"
 
-    By default, every input is assumed to be valid. Therefore, this functions does nothing. 
-    To customize this behavior add your own implementation of
+    By default, every input is assumed to be valid. Therefore, this function does nothing. 
+    To customize this behavior, add your own implementation of
 
     ```Julia
     _assert_valid_input(stp::YourCustomSetup,input)
     ```
-    which should throw an exception, which is subtype of [`AbstractInvalidInputError`](@ref). One may also use the concrete implementation [`InvalidInputError`](@ref) if the input is invalid, instead of writing a custom exception type.
+    which should throw an exception, which is a subtype of [`AbstractInvalidInputError`](@ref). One may also use the concrete implementation [`InvalidInputError`](@ref) if the input is invalid instead of writing a custom exception type.
 
 """
 @inline function _assert_valid_input(stp::AbstractComputationSetup, input)
@@ -129,7 +129,7 @@ Interface function that returns the value of the associated quantity evaluated o
 
 !!! note "unsafe implementation"
 
-    This function must be implemented for any subtype of [`AbstractComputationSetup`]. It should not do any input validation or post processing (see [`_assert_valid_input`](@ref) and [`_post_processing`](@ref)), as those two are performed while calling 
+    This function must be implemented for any subtype of [`AbstractComputationSetup`](@ref). It should not do any input validation or post processing (see [`_assert_valid_input`](@ref) and [`_post_processing`](@ref)), as those two are performed while calling 
     the safe version of this function [`compute`](@ref).
 
 """

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -10,8 +10,8 @@
 
 """
 Abstract base type for computation setups.  A *setup* means
-here, a collection of setup-data needed to evaluate a dedicated quantity on given
-running data. Therefore, each setup is associated to a single quantity, which one may compute using the setup data and the funning data. 
+a collection of setup data needed to evaluate a dedicated quantity of given
+running data. Therefore, each setup is associated with a single quantity, which one may compute using the setup data and the running data. 
 Despite that, the decomposition into setup and running data is
 arbitrary, and this can be used for cases where a subset of the variables a
 quantity depends on is kept constant. 
@@ -20,26 +20,26 @@ quantity depends on is kept constant.
     
     The computation performed using a computation setup is separated into three steps:
         
-        1. input validation,
-        2. actual computation,
-        3. post computation,
+        1. input validation
+        2. actual computation
+        3. post processing
 
     where every step has its own interface function (see [`compute`](@ref) for details). 
     
-    ## input validation
+    ## Input validation
 
-    Every subtype of `AbstractComputationSetup` implements the interface function
+    Every subtype of `AbstractComputationSetup` should implement the interface function
     
     ```Julia
     _input_validation(stp::AbstractComputationSetup, input) # default: true
     ```
     
-    which returns true, if the `input` is valid for the computation of the associated quantity (see [`_input_validation`](@ref) for more details). 
-    The default implementation returns always `true`; provide a custom implementation if a different behavior is required.
+    which should return true iff the `input` is valid for the computation of the associated quantity (see [`_input_validation`](@ref) for more details). 
+    The default implementation always returns `true`. Provide a custom implementation if a different behavior is required.
 
     ## Actual computation
     
-    Every subtype of `AbstractComputationSetup` should at least implement the following required interface function
+    Every subtype of `AbstractComputationSetup` must at least implement the required interface function
     
     ```Julia
     _compute(stp::AbstractComputationSetup, input) 
@@ -50,7 +50,7 @@ quantity depends on is kept constant.
 
     ## Post computation
 
-    Every subtype of `AbstractComputationSetup` implement the following interface function
+    Every subtype of `AbstractComputationSetup` should implement the interface function
     
     ```Julia
     _post_computation(stp::AbstractComputationSetup, input) 
@@ -70,13 +70,13 @@ _is_computation_setup(::AbstractComputationSetup) = true
 
     _is_valid_input(stp::AbstractComputationSetup, input::Any)
 
-Interface function, which returns true, if the constraints of the `input` associated with the quantity of `stp` are met.
-This function will be called to validate the input of [`compute`](@ref) before calling [`_compute`](@ref).
+Interface function, which returns true if the constraints of the `input` associated with the quantity of `stp` are met.
+This function is called to validate the input of [`compute`](@ref) before calling [`_compute`](@ref).
 
 !!! note "Default implementation"
     
-    Since no input validation is equivalent to every input being valid, this functions returns `true` per default. 
-    This behaviour needs to be overwritten, if this is not the case.
+    Since no input validation is equivalent to every input being valid, this function returns `true` by default. 
+    This behavior can be overwritten if actual validation is necessary.
 
 """
 @inline function _input_validation(stp::AbstractComputationSetup, input)
@@ -87,12 +87,12 @@ end
     
     function _post_computation(stp::AbstractComputationSetup, input::Any, result::Any)
     
-Interface functions which is called in [`compute`](@ref) after [`_compute`](@ref) was called. This function is dedicated to 
+Interface function, which is called in [`compute`](@ref) after [`_compute`](@ref) has been called. This function is dedicated to 
 finalize the result of a computation. 
 
 !!! note "default implementation"
 
-    Since in the case of no post computation, the result of [`_compute`](@ref) is not changed, this function returns `result` per default.
+    Since in the case of no post computation the result of [`_compute`](@ref) is unchanged, this function returns `result` by default.
 
 """
 @inline function _post_computation(stp::AbstractComputationSetup, input, result)
@@ -103,11 +103,11 @@ end
     
     _compute(stp::AbstractComputationSetup, input::Any)
 
-Interface function which returns the value of the associated quantity evaluated on `input`, which can be anything the associated quantity is defined to be feasable for.
+Interface function that returns the value of the associated quantity evaluated on `input`, which can be anything the associated quantity is defined to be feasible for.
 
 !!! note "unsafe implementation"
 
-    This function should be implemented without any input validation or post computations (see [`_input_validation`](@ref) and [`_post_computation`](@ref)). The latter two are performed while calling 
+    This function must be implemented for any subtype of [`AbstractComputationSetup`]. It should not do any input validation or post processing (see [`_input_validation`](@ref) and [`_post_computation`](@ref)), as those two are performed while calling 
     the safe version of this function [`compute`](@ref).
 
 """
@@ -129,16 +129,16 @@ function compute(stp::AbstractComputationSetup, input)
 end
 
 """
-Abstract base type for setups related to a combination scattering processes and compute models.  
-Every subtype of `AbstractProcessSetup` is expected to implement at least the following 
-interface functions
+Abstract base type for setups related to combining scattering processes and compute models.  
+Every subtype of `AbstractProcessSetup` must implement at least the following 
+interface functions:
 
 ```Julia
 scattering_process(::AbstractProcessSetup) 
 compute_model(::AbstractProcessSetup) 
 ```
 
-Derived from the these interface functions, the following delegations are implemented
+Derived from these interface functions, the following delegations are provided:
 
 ```Julia
 number_incoming_particles(::AbstractProcessSetup)
@@ -152,7 +152,7 @@ abstract type AbstractProcessSetup <: AbstractComputationSetup end
     
     scattering_process(stp::AbstractProcessSetup)
 
-Interface function, which returns the scattering process associated with `stp`,
+Interface function that returns the scattering process associated with `stp`,
 i.e. an object which is a subtype of `AbstractProcessDefinition`. 
 """
 function scattering_process end
@@ -161,8 +161,8 @@ function scattering_process end
 
     compute_model(stp::AbstractProcessSetup)
 
-Interface function, which returns the compute model associated with `stp`, i.e.
-an object which is subtype of `AbstractModelDefinition`
+Interface function that returns the compute model associated with `stp`, i.e.
+an object which is a subtype of `AbstractModelDefinition`.
 """
 function compute_model end
 

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -1,0 +1,114 @@
+###############
+# The process setup 
+#
+# In this file, we define the interface for process setups. A `setup` means
+# here, a collection of setup-data needed to evaluate a dedicated quantity on a given
+# running data. Despite that, the decomposition into setup and running data is
+# arbitrary, this will be used for cases where a subset of the variables a
+# quantity depends on is kept constant.  
+# 
+# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
+# ecosystem.
+#
+###############
+
+# base type for any setup, will most properbly be defined somewhere else,
+# e.g. QEDbase, therefore it is not exported
+abstract type AbstractComputationSetup end
+
+"""
+
+    _is_valid_input(stp::AbstractComputationSetup, input::Any)
+
+Interface function, which returns true, if the constraints of the `input` associated with the quantity of `stp` are met.
+This function will be called to validate the input of [`compute`](@ref) before calling [`_compute`](@ref).
+
+!!! note "Default implementation"
+    
+    Since no input validation is equivalent to every input being valid, this functions returns `true` per default. 
+    This behaviour needs to be overwritten, if this is not the case.
+
+"""
+@inline function _input_validation(stp::AbstractComputationSetup, input)
+    return true
+end
+
+"""
+    
+    function _post_computation(stp::AbstractComputationSetup, input::Any, result::Any)
+    
+Interface functions which is called in [`compute`](@ref) after [`_compute`](@ref) was called. This function is dedicated to 
+finalize the result of a computation. 
+
+!!! note "default implementation"
+
+    Since in the case of no post computation, the result of [`_compute`](@ref) is not changed, this function returns `result` per default.
+
+"""
+@inline function _post_computation(stp::AbstractComputationSetup, input, result)
+    return result
+end
+
+"""
+    
+    _compute(stp::AbstractComputationSetup, input::Any)
+
+Interface function which returns the value of the associated quantity evaluated on `input`, which can be anything the associated quantity is defined to be feasable for.
+
+!!! note "unsafe implementation"
+
+    This function should be implemented without any input validation or post computations (see [`_input_validation`](@ref) and [`_post_computation`](@ref)). The latter two are performed while calling 
+    the safe version of this function [`compute`](@ref).
+
+"""
+function _compute end
+
+
+
+function compute(stp::AbstractComputationSetup, input)
+    _input_validation(stp,input) || error("InvalidInputError: there is something wrong with the input!\n setup:$stp \n input:$input")
+    raw_result = _compute(stp,input)
+    return _post_computation(stp, input,raw_result)
+end
+
+"""
+Abstract base type for setups related to a combination scattering processes and compute models.  
+Every subtype of `AbstractProcessSetup` is expected to implement at least the following 
+interface functions
+
+```Julia
+scattering_process(::AbstractProcessSetup) 
+compute_model(::AbstractProcessSetup) 
+```
+where `x` is the running input, i.e. a *single point* the quantity is evaluated on.
+
+Derived from the these interface functions, the following delegations are implemented
+
+```Julia
+number_incoming_particles(::AbstractProcessSetup)
+number_outgoing_particles(::AbstractProcessSetup)
+```
+"""
+abstract type AbstractProcessSetup <: AbstractComputationSetup end
+
+"""
+    
+    scattering_process(stp::AbstractProcessSetup)
+
+Interface function, which returns the scattering process associated with `stp`,
+i.e. an object which is a subtype of `AbstractProcessDefinition`. 
+"""
+function scattering_process end
+
+"""
+
+    compute_model(stp::AbstractProcessSetup)
+
+Interface function, which returns the compute model associated with `stp`, i.e.
+an object which is subtype of `AbstractModelDefinition`
+"""
+function compute_model end
+
+@inline number_incoming_particles(stp::AbstractProcessSetup) = number_incoming_particles(scattering_process(stp))
+@inline number_outgoing_particles(stp::AbstractProcessSetup) = number_outgoing_particles(scattering_process(stp))
+

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -52,7 +52,7 @@ quantity depends on is kept constant.
     _post_computation(stp::AbstractComputationSetup, input) 
     ```
     
-    which performs *computations* after the actual computation, e.g. conversions or normalisations (see [`_post_computation`](@ref) for more details).
+    which performs *computations* after the actual computation, e.g. conversions or normalizations (see [`_post_computation`](@ref) for more details).
 
 
     
@@ -75,7 +75,7 @@ This function is called to validate the input of [`compute`](@ref) before callin
     This behavior can be overwritten if actual validation is necessary.
 
 
-An assert version of this function is given by [`_assert_valid_input`](@ref), which used directly the output of this function.
+An assert version of this function is given by [`_assert_valid_input`](@ref), which directly uses the output of this function.
 
 """
 @inline function _is_valid_input(stp::AbstractComputationSetup, input)
@@ -109,7 +109,7 @@ Interface function, which asserts that the given `input` is valid, and throws an
     _assert_valid_input(stp::YourCustomSetup,input)
     ```
     which should throw an [`InvalidInputError`](@ref) if the input is invalid.
-    Dispite the presence of a custom `_assert_valid_input`, it is highly recommented to also implement `_is_valid_input` for `CustomSetup`, because it might be used outside the assert function.
+    Despite the presence of a custom `_assert_valid_input`, it is highly recommended to also implement `_is_valid_input` for `CustomSetup`, because it might be used outside of the assert function.
 
 """
 @inline function _assert_valid_input(stp::AbstractComputationSetup,input)

--- a/src/particle_types.jl
+++ b/src/particle_types.jl
@@ -3,9 +3,6 @@
 #
 # In this file, we define the types of particles used in `QEDprocesses.jl` and
 # implement the abstact particle interface accordingly. 
-# 
-# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
-# ecosystem.
 ###############
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -2,9 +2,6 @@
 # utility functions
 #
 # This file contains small helper and utility functions used throughout the package.
-#
-# This file is part of `QEDprocesses.jl` which is by itself part of the `QED.jl`
-# ecosystem.
 ###############
 
 

--- a/test/interfaces/process_interface.jl
+++ b/test/interfaces/process_interface.jl
@@ -77,6 +77,11 @@ end
         @test outgoing_particles(TestProcess()) == OUTGOING_PARTICLES
     end
 
+    @testset "delegated functions" begin
+        @test number_incoming_particles(TestProcess()) == N_INCOMING
+        @test number_outgoing_particles(TestProcess()) == N_OUTGOING
+    end
+
 
     @testset "cross section" begin
 

--- a/test/interfaces/setup_interface.jl
+++ b/test/interfaces/setup_interface.jl
@@ -1,0 +1,90 @@
+
+using Random
+using QEDbase
+using QEDprocesses
+
+RNG = MersenneTwister(137137)
+ATOL = 0.0
+RTOL = sqrt(eps())
+
+
+
+_groundthruth_compute(x) = x
+_groundthruth_input_validation(x) = (x>0)
+_transform_to_invalid(x) = -abs(x)
+_groundtruth_post_computation(x,y) = x+y
+
+abstract type AbstractTestSetup <: AbstractComputationSetup end
+QEDprocesses._compute(stp::AbstractTestSetup, x) = _groundthruth_compute(x)
+
+struct TestSetupDefault <: AbstractTestSetup end
+
+struct TestSetupCustomValidation <: AbstractTestSetup end 
+QEDprocesses._input_validation(::TestSetupCustomValidation, x) = _groundthruth_input_validation(x)
+
+struct TestSetupCustomPostComputation <: AbstractTestSetup end
+QEDprocesses._post_computation(::TestSetupCustomPostComputation,x,y) = _groundtruth_post_computation(x,y)
+
+struct TestSetupCustom <: AbstractTestSetup end 
+QEDprocesses._input_validation(::TestSetupCustom, x) = _groundthruth_input_validation(x)
+QEDprocesses._post_computation(::TestSetupCustom,x,y) = _groundtruth_post_computation(x,y)
+
+# setups which fail on computation
+struct TestSetupFAIL <: AbstractComputationSetup end
+
+struct TestSetupCustomValidationFAIL <: AbstractComputationSetup end
+QEDprocesses._input_validation(::TestSetupCustomValidationFAIL, x) = _groundthruth_input_validation(x)
+
+struct TestSetupCustomPostComputationFAIL <: AbstractComputationSetup end
+QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _groundtruth_post_computation(x,y)
+
+@testset "interface fail" begin
+    @test_throws MethodError QEDprocesses._compute(TestSetupFAIL()) 
+    @test_throws MethodError compute(TestSetupFAIL()) 
+
+    @test_throws MethodError QEDprocesses._compute(TestSetupCustomValidationFAIL()) 
+    @test_throws MethodError compute(TestSetupCustomValidationFAIL()) 
+
+    @test_throws MethodError QEDprocesses._compute(TestSetupCustomPostComputationFAIL()) 
+    @test_throws MethodError compute(TestSetupCustomPostComputationFAIL()) 
+end
+
+@testset "default interface" begin
+    stp = TestSetupDefault()
+
+    rnd_input = rand(RNG)
+    rnd_output = rand(RNG)
+    @test QEDprocesses._input_validation(stp,rnd_input)
+    @test QEDprocesses._post_computation(stp,rnd_input,rnd_output) == rnd_output
+    @test isapprox(QEDprocesses._compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
+    @test isapprox(compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
+end
+
+@testset "custom input validation" begin
+    stp = TestSetupCustomValidation()
+    rnd_input = rand(RNG)
+    @test QEDprocesses._input_validation(stp, _groundthruth_input_validation(rnd_input))
+    @test !QEDprocesses._input_validation(stp, !_groundthruth_input_validation(rnd_input))
+    @test isapprox(compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
+    @test_throws ErrorException compute(stp, _transform_to_invalid(rnd_input))
+end
+
+@testset "custom post computation" begin
+    stp = TestSetupCustomPostComputation()
+    rnd_input = rand(RNG)
+    rnd_output = rand(RNG)
+    @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
+    @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundthruth_compute(rnd_input)))
+end
+
+@testset "custom input validation and post computation" begin
+    stp = TestSetupCustom()
+    rnd_input = rand(RNG)
+    rnd_output = rand(RNG)
+
+    @test QEDprocesses._input_validation(stp, _groundthruth_input_validation(rnd_input))
+    @test !QEDprocesses._input_validation(stp, !_groundthruth_input_validation(rnd_input))
+    @test_throws ErrorException compute(stp, _transform_to_invalid(rnd_input))
+    @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
+    @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundthruth_compute(rnd_input)))
+end

--- a/test/interfaces/setup_interface.jl
+++ b/test/interfaces/setup_interface.jl
@@ -84,7 +84,6 @@ QEDprocesses._post_processing(::TestSetupCustomPostProcessingFAIL, x, y) =
 
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
-        @test QEDprocesses._is_valid_input(stp, rnd_input)
         @test QEDprocesses._post_processing(stp, rnd_input, rnd_output) == rnd_output
         @test isapprox(
             QEDprocesses._compute(stp, rnd_input),
@@ -103,8 +102,6 @@ QEDprocesses._post_processing(::TestSetupCustomPostProcessingFAIL, x, y) =
     @testset "custom input validation" begin
         stp = TestSetupCustomAssertValidInput()
         rnd_input = rand(RNG)
-        @test QEDprocesses._is_valid_input(stp, _groundtruth_input_validation(rnd_input))
-        @test !QEDprocesses._is_valid_input(stp, !_groundtruth_input_validation(rnd_input))
         @test QEDprocesses._assert_valid_input(stp, rnd_input) == nothing
         @test_throws TestException QEDprocesses._assert_valid_input(
             stp,
@@ -133,8 +130,6 @@ QEDprocesses._post_processing(::TestSetupCustomPostProcessingFAIL, x, y) =
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
 
-        @test QEDprocesses._is_valid_input(stp, _groundtruth_input_validation(rnd_input))
-        @test !QEDprocesses._is_valid_input(stp, !_groundtruth_input_validation(rnd_input))
         @test_throws TestException() compute(stp, _transform_to_invalid(rnd_input))
         @test isapprox(
             QEDprocesses._post_processing(stp, rnd_input, rnd_output),

--- a/test/interfaces/setup_interface.jl
+++ b/test/interfaces/setup_interface.jl
@@ -7,84 +7,142 @@ RNG = MersenneTwister(137137)
 ATOL = 0.0
 RTOL = sqrt(eps())
 
-
-
 _groundthruth_compute(x) = x
 _groundthruth_input_validation(x) = (x>0)
 _transform_to_invalid(x) = -abs(x)
 _groundtruth_post_computation(x,y) = x+y
 
+# setups for which the interface is implemented
 abstract type AbstractTestSetup <: AbstractComputationSetup end
 QEDprocesses._compute(stp::AbstractTestSetup, x) = _groundthruth_compute(x)
 
+# setup with default implementations
 struct TestSetupDefault <: AbstractTestSetup end
 
+# setup with custom input validation
 struct TestSetupCustomValidation <: AbstractTestSetup end 
 QEDprocesses._input_validation(::TestSetupCustomValidation, x) = _groundthruth_input_validation(x)
 
+# setup with custom post computation
 struct TestSetupCustomPostComputation <: AbstractTestSetup end
 QEDprocesses._post_computation(::TestSetupCustomPostComputation,x,y) = _groundtruth_post_computation(x,y)
 
+# setup with custom input validation and post computation
 struct TestSetupCustom <: AbstractTestSetup end 
 QEDprocesses._input_validation(::TestSetupCustom, x) = _groundthruth_input_validation(x)
 QEDprocesses._post_computation(::TestSetupCustom,x,y) = _groundtruth_post_computation(x,y)
 
-# setups which fail on computation
+# setup which fail on computation with default implementations
 struct TestSetupFAIL <: AbstractComputationSetup end
 
+# setup which fail on computation with custom input validation
 struct TestSetupCustomValidationFAIL <: AbstractComputationSetup end
 QEDprocesses._input_validation(::TestSetupCustomValidationFAIL, x) = _groundthruth_input_validation(x)
 
+# setup which fail on computation with custom post computation
 struct TestSetupCustomPostComputationFAIL <: AbstractComputationSetup end
 QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _groundtruth_post_computation(x,y)
+@testset "general computation setup interface" begin
+    @testset "interface fail" begin
+        rnd_input = rand(RNG)
+        @test_throws MethodError QEDprocesses._compute(TestSetupFAIL(), rnd_input) 
+        @test_throws MethodError compute(TestSetupFAIL(), rnd_input) 
 
-@testset "interface fail" begin
-    @test_throws MethodError QEDprocesses._compute(TestSetupFAIL()) 
-    @test_throws MethodError compute(TestSetupFAIL()) 
+        @test_throws MethodError QEDprocesses._compute(TestSetupCustomValidationFAIL(), rnd_input) 
+        @test_throws MethodError compute(TestSetupCustomValidationFAIL(), rnd_input) 
+        # invalid input should be catched without throwing a MethodError
+        @test_throws ErrorException compute(TestSetupCustomValidationFAIL(), _transform_to_invalid(rnd_input)) 
 
-    @test_throws MethodError QEDprocesses._compute(TestSetupCustomValidationFAIL()) 
-    @test_throws MethodError compute(TestSetupCustomValidationFAIL()) 
+        @test_throws MethodError QEDprocesses._compute(TestSetupCustomPostComputationFAIL(), rnd_input) 
+        @test_throws MethodError compute(TestSetupCustomPostComputationFAIL(), rnd_input) 
+    end
 
-    @test_throws MethodError QEDprocesses._compute(TestSetupCustomPostComputationFAIL()) 
-    @test_throws MethodError compute(TestSetupCustomPostComputationFAIL()) 
+    @testset "default interface" begin
+        stp = TestSetupDefault()
+
+        rnd_input = rand(RNG)
+        rnd_output = rand(RNG)
+        @test QEDprocesses._input_validation(stp,rnd_input)
+        @test QEDprocesses._post_computation(stp,rnd_input,rnd_output) == rnd_output
+        @test isapprox(QEDprocesses._compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
+        @test isapprox(compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
+    end
+
+    @testset "custom input validation" begin
+        stp = TestSetupCustomValidation()
+        rnd_input = rand(RNG)
+        @test QEDprocesses._input_validation(stp, _groundthruth_input_validation(rnd_input))
+        @test !QEDprocesses._input_validation(stp, !_groundthruth_input_validation(rnd_input))
+        @test isapprox(compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
+        @test_throws ErrorException compute(stp, _transform_to_invalid(rnd_input))
+    end
+
+    @testset "custom post computation" begin
+        stp = TestSetupCustomPostComputation()
+        rnd_input = rand(RNG)
+        rnd_output = rand(RNG)
+        @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
+        @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundthruth_compute(rnd_input)))
+    end
+
+    @testset "custom input validation and post computation" begin
+        stp = TestSetupCustom()
+        rnd_input = rand(RNG)
+        rnd_output = rand(RNG)
+
+        @test QEDprocesses._input_validation(stp, _groundthruth_input_validation(rnd_input))
+        @test !QEDprocesses._input_validation(stp, !_groundthruth_input_validation(rnd_input))
+        @test_throws ErrorException compute(stp, _transform_to_invalid(rnd_input))
+        @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
+        @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundthruth_compute(rnd_input)))
+    end
 end
+# process setup 
 
-@testset "default interface" begin
-    stp = TestSetupDefault()
+struct TestParticle1 <: AbstractParticle end
+struct TestParticle2 <: AbstractParticle end
+struct TestParticle3 <: AbstractParticle end
+struct TestParticle4 <: AbstractParticle end
 
-    rnd_input = rand(RNG)
-    rnd_output = rand(RNG)
-    @test QEDprocesses._input_validation(stp,rnd_input)
-    @test QEDprocesses._post_computation(stp,rnd_input,rnd_output) == rnd_output
-    @test isapprox(QEDprocesses._compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
-    @test isapprox(compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
-end
+PARTICLE_SET = [TestParticle1(), TestParticle2(), TestParticle3(),TestParticle4()]
 
-@testset "custom input validation" begin
-    stp = TestSetupCustomValidation()
-    rnd_input = rand(RNG)
-    @test QEDprocesses._input_validation(stp, _groundthruth_input_validation(rnd_input))
-    @test !QEDprocesses._input_validation(stp, !_groundthruth_input_validation(rnd_input))
-    @test isapprox(compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
-    @test_throws ErrorException compute(stp, _transform_to_invalid(rnd_input))
-end
+struct TestProcess <: AbstractProcessDefinition end
+struct TestModel <: AbstractModelDefinition end
 
-@testset "custom post computation" begin
-    stp = TestSetupCustomPostComputation()
-    rnd_input = rand(RNG)
-    rnd_output = rand(RNG)
-    @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
-    @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundthruth_compute(rnd_input)))
-end
+struct TestProcessSetup <: AbstractProcessSetup end
+QEDprocesses.scattering_process(::TestProcessSetup) = TestProcess()
+QEDprocesses.compute_model(::TestProcessSetup) = TestModel()
 
-@testset "custom input validation and post computation" begin
-    stp = TestSetupCustom()
-    rnd_input = rand(RNG)
-    rnd_output = rand(RNG)
+struct TestProcessSetupFAIL <: AbstractProcessSetup end
 
-    @test QEDprocesses._input_validation(stp, _groundthruth_input_validation(rnd_input))
-    @test !QEDprocesses._input_validation(stp, !_groundthruth_input_validation(rnd_input))
-    @test_throws ErrorException compute(stp, _transform_to_invalid(rnd_input))
-    @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
-    @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundthruth_compute(rnd_input)))
+@testset "process setup interface" begin
+    @testset "interface fail" begin
+        @test_throws MethodError scattering_process(TestProcessSetupFAIL)
+        @test_throws MethodError compute_model(TestProcessSetupFAIL)
+    end
+
+    @testset "hard interface" begin
+        stp = TestProcessSetup()
+        
+        @test QEDprocesses._is_computation_setup(stp) 
+        @test scattering_process(stp) == TestProcess()
+        @test compute_model(stp) == TestModel()
+    end
+
+    @testset "($N_INCOMING,$N_OUTGOING)" for (N_INCOMING,N_OUTGOING) in Iterators.product(
+                                                                                          (1, rand(RNG, 2:8)), (1, rand(RNG, 2:8))
+                                                                                         )   
+        INCOMING_PARTICLES = rand(RNG,PARTICLE_SET,N_INCOMING)
+        OUTGOING_PARTICLES = rand(RNG,PARTICLE_SET,N_OUTGOING)
+
+        QEDprocesses.incoming_particles(::TestProcess) = INCOMING_PARTICLES
+        QEDprocesses.outgoing_particles(::TestProcess) = OUTGOING_PARTICLES 
+
+        @testset "deligated functions" begin
+            stp = TestProcessSetup()
+            @test number_incoming_particles(stp) == N_INCOMING
+            @test number_outgoing_particles(stp) == N_OUTGOING
+        end
+
+    end
 end

--- a/test/interfaces/setup_interface.jl
+++ b/test/interfaces/setup_interface.jl
@@ -60,7 +60,7 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
         @test_throws MethodError QEDprocesses._compute(TestSetupCustomValidationFAIL(), rnd_input) 
         @test_throws MethodError compute(TestSetupCustomValidationFAIL(), rnd_input) 
         # invalid input should be caught without throwing a MethodError
-        @test_throws ErrorException compute(TestSetupCustomValidationFAIL(), _transform_to_invalid(rnd_input)) 
+        @test_throws InvalidInputError compute(TestSetupCustomValidationFAIL(), _transform_to_invalid(rnd_input)) 
 
         @test_throws MethodError QEDprocesses._compute(TestSetupCustomPostComputationFAIL(), rnd_input) 
         @test_throws MethodError compute(TestSetupCustomPostComputationFAIL(), rnd_input) 
@@ -83,9 +83,9 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
         @test QEDprocesses._is_valid_input(stp, _groundthruth_input_validation(rnd_input))
         @test !QEDprocesses._is_valid_input(stp, !_groundthruth_input_validation(rnd_input))
         @test isapprox(compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
-        @test_throws ErrorException QEDprocesses._assert_valid_input(stp, _transform_to_invalid(rnd_input))
-        @test_throws ErrorException compute(stp, _transform_to_invalid(rnd_input))
-
+        @test_throws InvalidInputError QEDprocesses._assert_valid_input(stp, _transform_to_invalid(rnd_input))
+        @test_throws InvalidInputError compute(stp, _transform_to_invalid(rnd_input))
+ 
         stp2 = TestSetupCustomAssertValidInput()
         rnd_input2 = rand(RNG)
         @test QEDprocesses._assert_valid_input(stp2,rnd_input2)==nothing
@@ -109,7 +109,7 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
 
         @test QEDprocesses._is_valid_input(stp, _groundthruth_input_validation(rnd_input))
         @test !QEDprocesses._is_valid_input(stp, !_groundthruth_input_validation(rnd_input))
-        @test_throws ErrorException compute(stp, _transform_to_invalid(rnd_input))
+        @test_throws InvalidInputError compute(stp, _transform_to_invalid(rnd_input))
         @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
         @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundthruth_compute(rnd_input)))
     end

--- a/test/interfaces/setup_interface.jl
+++ b/test/interfaces/setup_interface.jl
@@ -7,25 +7,25 @@ RNG = MersenneTwister(137137)
 ATOL = 0.0
 RTOL = sqrt(eps())
 
-_groundthruth_compute(x) = x
-_groundthruth_input_validation(x) = (x>0)
+_groundtruth_compute(x) = x
+_groundtruth_input_validation(x) = (x>0)
 _transform_to_invalid(x) = -abs(x)
 _groundtruth_post_computation(x,y) = x+y
 
 # setups for which the interface is implemented
 abstract type AbstractTestSetup <: AbstractComputationSetup end
-QEDprocesses._compute(stp::AbstractTestSetup, x) = _groundthruth_compute(x)
+QEDprocesses._compute(stp::AbstractTestSetup, x) = _groundtruth_compute(x)
 
 # setup with default implementations
 struct TestSetupDefault <: AbstractTestSetup end
 
 # setup with custom _is_valid_input 
 struct TestSetupCustomIsValidInput <: AbstractTestSetup end 
-QEDprocesses._is_valid_input(::TestSetupCustomIsValidInput, x) = _groundthruth_input_validation(x)
+QEDprocesses._is_valid_input(::TestSetupCustomIsValidInput, x) = _groundtruth_input_validation(x)
 
 # setup with custom _assert_valid_input 
 struct TestSetupCustomAssertValidInput<: AbstractTestSetup end 
-QEDprocesses._is_valid_input(::TestSetupCustomAssertValidInput, x) = _groundthruth_input_validation(x)
+QEDprocesses._is_valid_input(::TestSetupCustomAssertValidInput, x) = _groundtruth_input_validation(x)
 struct TestException <: Exception end
 function QEDprocesses._assert_valid_input(stp::TestSetupCustomAssertValidInput, x) 
     QEDprocesses._is_valid_input(stp,x)||throw(TestException())
@@ -38,7 +38,7 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputation,x,y) = _groundtr
 
 # setup with custom input validation and post computation
 struct TestSetupCustom <: AbstractTestSetup end 
-QEDprocesses._is_valid_input(::TestSetupCustom, x) = _groundthruth_input_validation(x)
+QEDprocesses._is_valid_input(::TestSetupCustom, x) = _groundtruth_input_validation(x)
 QEDprocesses._post_computation(::TestSetupCustom,x,y) = _groundtruth_post_computation(x,y)
 
 # setup which fail on computation with default implementations
@@ -46,7 +46,7 @@ struct TestSetupFAIL <: AbstractComputationSetup end
 
 # setup which fail on computation with custom input validation
 struct TestSetupCustomValidationFAIL <: AbstractComputationSetup end
-QEDprocesses._is_valid_input(::TestSetupCustomValidationFAIL, x) = _groundthruth_input_validation(x)
+QEDprocesses._is_valid_input(::TestSetupCustomValidationFAIL, x) = _groundtruth_input_validation(x)
 
 # setup which fail on computation with custom post computation
 struct TestSetupCustomPostComputationFAIL <: AbstractComputationSetup end
@@ -73,16 +73,16 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
         rnd_output = rand(RNG)
         @test QEDprocesses._is_valid_input(stp,rnd_input)
         @test QEDprocesses._post_computation(stp,rnd_input,rnd_output) == rnd_output
-        @test isapprox(QEDprocesses._compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
-        @test isapprox(compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
+        @test isapprox(QEDprocesses._compute(stp, rnd_input), _groundtruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
+        @test isapprox(compute(stp, rnd_input), _groundtruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
     end
 
     @testset "custom input validation" begin
         stp = TestSetupCustomIsValidInput()
         rnd_input = rand(RNG)
-        @test QEDprocesses._is_valid_input(stp, _groundthruth_input_validation(rnd_input))
-        @test !QEDprocesses._is_valid_input(stp, !_groundthruth_input_validation(rnd_input))
-        @test isapprox(compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
+        @test QEDprocesses._is_valid_input(stp, _groundtruth_input_validation(rnd_input))
+        @test !QEDprocesses._is_valid_input(stp, !_groundtruth_input_validation(rnd_input))
+        @test isapprox(compute(stp, rnd_input), _groundtruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
         @test_throws InvalidInputError QEDprocesses._assert_valid_input(stp, _transform_to_invalid(rnd_input))
         @test_throws InvalidInputError compute(stp, _transform_to_invalid(rnd_input))
  
@@ -99,7 +99,7 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
         @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
-        @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundthruth_compute(rnd_input)))
+        @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundtruth_compute(rnd_input)))
     end
 
     @testset "custom input validation and post computation" begin
@@ -107,11 +107,11 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
 
-        @test QEDprocesses._is_valid_input(stp, _groundthruth_input_validation(rnd_input))
-        @test !QEDprocesses._is_valid_input(stp, !_groundthruth_input_validation(rnd_input))
+        @test QEDprocesses._is_valid_input(stp, _groundtruth_input_validation(rnd_input))
+        @test !QEDprocesses._is_valid_input(stp, !_groundtruth_input_validation(rnd_input))
         @test_throws InvalidInputError compute(stp, _transform_to_invalid(rnd_input))
         @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
-        @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundthruth_compute(rnd_input)))
+        @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundtruth_compute(rnd_input)))
     end
 end
 # process setup 

--- a/test/interfaces/setup_interface.jl
+++ b/test/interfaces/setup_interface.jl
@@ -128,7 +128,7 @@ struct TestModel <: AbstractModelDefinition end
 
 struct TestProcessSetup <: AbstractProcessSetup end
 QEDprocesses.scattering_process(::TestProcessSetup) = TestProcess()
-QEDprocesses.compute_model(::TestProcessSetup) = TestModel()
+QEDprocesses.physical_model(::TestProcessSetup) = TestModel()
 
 struct TestProcessSetupFAIL <: AbstractProcessSetup end
 
@@ -136,7 +136,7 @@ struct TestProcessSetupFAIL <: AbstractProcessSetup end
     @testset "interface fail" begin
         rnd_input = rand(RNG)
         @test_throws MethodError scattering_process(TestProcessSetupFAIL())
-        @test_throws MethodError compute_model(TestProcessSetupFAIL())
+        @test_throws MethodError physical_model(TestProcessSetupFAIL())
         @test_throws MethodError QEDprocesses._compute(TestProcessSetupFAIL(), rnd_input)
     end
 
@@ -145,7 +145,7 @@ struct TestProcessSetupFAIL <: AbstractProcessSetup end
         
         @test QEDprocesses._is_computation_setup(stp) 
         @test scattering_process(stp) == TestProcess()
-        @test compute_model(stp) == TestModel()
+        @test physical_model(stp) == TestModel()
     end
 
     @testset "($N_INCOMING,$N_OUTGOING)" for (N_INCOMING,N_OUTGOING) in Iterators.product(

--- a/test/interfaces/setup_interface.jl
+++ b/test/interfaces/setup_interface.jl
@@ -8,14 +8,14 @@ ATOL = 0.0
 RTOL = sqrt(eps())
 
 _groundtruth_compute(x) = x
-_groundtruth_input_validation(x) = (x>0)
+_groundtruth_input_validation(x) = (x > 0)
 struct TestException <: QEDprocesses.AbstractInvalidInputException end
 function _groundtruth_valid_input_assert(x)
-    _groundtruth_input_validation(x)||throw(TestException())
+    _groundtruth_input_validation(x) || throw(TestException())
     nothing
 end
 _transform_to_invalid(x) = -abs(x)
-_groundtruth_post_processing(x,y) = x+y
+_groundtruth_post_processing(x, y) = x + y
 
 # setups for which the interface is implemented
 abstract type AbstractTestSetup <: AbstractComputationSetup end
@@ -25,17 +25,20 @@ QEDprocesses._compute(stp::AbstractTestSetup, x) = _groundtruth_compute(x)
 struct TestSetupDefault <: AbstractTestSetup end
 
 # setup with custom _assert_valid_input 
-struct TestSetupCustomAssertValidInput<: AbstractTestSetup end 
-QEDprocesses._assert_valid_input(stp::TestSetupCustomAssertValidInput, x) = _groundtruth_valid_input_assert(x)
+struct TestSetupCustomAssertValidInput <: AbstractTestSetup end
+QEDprocesses._assert_valid_input(stp::TestSetupCustomAssertValidInput, x) =
+    _groundtruth_valid_input_assert(x)
 
 # setup with custom post processing 
-struct TestSetupCustomPostProcessing<: AbstractTestSetup end
-QEDprocesses._post_processing(::TestSetupCustomPostProcessing,x,y) = _groundtruth_post_processing(x,y)
+struct TestSetupCustomPostProcessing <: AbstractTestSetup end
+QEDprocesses._post_processing(::TestSetupCustomPostProcessing, x, y) =
+    _groundtruth_post_processing(x, y)
 
 # setup with custom input validation and post processing 
-struct TestSetupCustom <: AbstractTestSetup end 
-QEDprocesses._assert_valid_input(stp::TestSetupCustom, x) = _groundtruth_valid_input_assert(x)
-QEDprocesses._post_processing(::TestSetupCustom,x,y) = _groundtruth_post_processing(x,y)
+struct TestSetupCustom <: AbstractTestSetup end
+QEDprocesses._assert_valid_input(stp::TestSetupCustom, x) =
+    _groundtruth_valid_input_assert(x)
+QEDprocesses._post_processing(::TestSetupCustom, x, y) = _groundtruth_post_processing(x, y)
 
 # setup which fail on computation with default implementations
 struct TestSetupFAIL <: AbstractComputationSetup end
@@ -43,26 +46,37 @@ struct TestSetupFAIL <: AbstractComputationSetup end
 # setup which fail on computation with custom input validation, where the
 # invalid input will be caught before the computation.
 struct TestSetupCustomValidationFAIL <: AbstractComputationSetup end
-QEDprocesses._assert_valid_input(stp::TestSetupCustomValidationFAIL, x) = _groundtruth_valid_input_assert(x)
+QEDprocesses._assert_valid_input(stp::TestSetupCustomValidationFAIL, x) =
+    _groundtruth_valid_input_assert(x)
 
 # setup which fail on computation with custom post processing
 struct TestSetupCustomPostProcessingFAIL <: AbstractComputationSetup end
-QEDprocesses._post_processing(::TestSetupCustomPostProcessingFAIL,x,y) = _groundtruth_post_processing(x,y)
+QEDprocesses._post_processing(::TestSetupCustomPostProcessingFAIL, x, y) =
+    _groundtruth_post_processing(x, y)
 @testset "general computation setup interface" begin
     @testset "interface fail" begin
         rnd_input = rand(RNG)
 
-        @test_throws MethodError QEDprocesses._compute(TestSetupFAIL(), rnd_input) 
-        @test_throws MethodError compute(TestSetupFAIL(), rnd_input) 
+        @test_throws MethodError QEDprocesses._compute(TestSetupFAIL(), rnd_input)
+        @test_throws MethodError compute(TestSetupFAIL(), rnd_input)
 
-        @test_throws MethodError QEDprocesses._compute(TestSetupCustomValidationFAIL(), rnd_input) 
-        @test_throws MethodError compute(TestSetupCustomValidationFAIL(), rnd_input) 
+        @test_throws MethodError QEDprocesses._compute(
+            TestSetupCustomValidationFAIL(),
+            rnd_input,
+        )
+        @test_throws MethodError compute(TestSetupCustomValidationFAIL(), rnd_input)
         # invalid input should be caught without throwing a MethodError
-        @test_throws TestException compute(TestSetupCustomValidationFAIL(), _transform_to_invalid(rnd_input)) 
+        @test_throws TestException compute(
+            TestSetupCustomValidationFAIL(),
+            _transform_to_invalid(rnd_input),
+        )
 
 
-        @test_throws MethodError QEDprocesses._compute(TestSetupCustomPostProcessingFAIL(), rnd_input) 
-        @test_throws MethodError compute(TestSetupCustomPostProcessingFAIL(), rnd_input) 
+        @test_throws MethodError QEDprocesses._compute(
+            TestSetupCustomPostProcessingFAIL(),
+            rnd_input,
+        )
+        @test_throws MethodError compute(TestSetupCustomPostProcessingFAIL(), rnd_input)
     end
 
     @testset "default interface" begin
@@ -70,10 +84,20 @@ QEDprocesses._post_processing(::TestSetupCustomPostProcessingFAIL,x,y) = _ground
 
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
-        @test QEDprocesses._is_valid_input(stp,rnd_input)
-        @test QEDprocesses._post_processing(stp,rnd_input,rnd_output) == rnd_output
-        @test isapprox(QEDprocesses._compute(stp, rnd_input), _groundtruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
-        @test isapprox(compute(stp, rnd_input), _groundtruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
+        @test QEDprocesses._is_valid_input(stp, rnd_input)
+        @test QEDprocesses._post_processing(stp, rnd_input, rnd_output) == rnd_output
+        @test isapprox(
+            QEDprocesses._compute(stp, rnd_input),
+            _groundtruth_compute(rnd_input),
+            atol = ATOL,
+            rtol = RTOL,
+        )
+        @test isapprox(
+            compute(stp, rnd_input),
+            _groundtruth_compute(rnd_input),
+            atol = ATOL,
+            rtol = RTOL,
+        )
     end
 
     @testset "custom input validation" begin
@@ -81,8 +105,11 @@ QEDprocesses._post_processing(::TestSetupCustomPostProcessingFAIL,x,y) = _ground
         rnd_input = rand(RNG)
         @test QEDprocesses._is_valid_input(stp, _groundtruth_input_validation(rnd_input))
         @test !QEDprocesses._is_valid_input(stp, !_groundtruth_input_validation(rnd_input))
-        @test QEDprocesses._assert_valid_input(stp,rnd_input)==nothing
-        @test_throws TestException QEDprocesses._assert_valid_input(stp,_transform_to_invalid(rnd_input))
+        @test QEDprocesses._assert_valid_input(stp, rnd_input) == nothing
+        @test_throws TestException QEDprocesses._assert_valid_input(
+            stp,
+            _transform_to_invalid(rnd_input),
+        )
         @test_throws TestException compute(stp, _transform_to_invalid(rnd_input))
 
     end
@@ -91,20 +118,32 @@ QEDprocesses._post_processing(::TestSetupCustomPostProcessingFAIL,x,y) = _ground
         stp = TestSetupCustomPostProcessing()
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
-        @test isapprox(QEDprocesses._post_processing(stp,rnd_input,rnd_output), _groundtruth_post_processing(rnd_input,rnd_output))
-        @test isapprox(compute(stp,rnd_input), _groundtruth_post_processing(rnd_input,_groundtruth_compute(rnd_input)))
+        @test isapprox(
+            QEDprocesses._post_processing(stp, rnd_input, rnd_output),
+            _groundtruth_post_processing(rnd_input, rnd_output),
+        )
+        @test isapprox(
+            compute(stp, rnd_input),
+            _groundtruth_post_processing(rnd_input, _groundtruth_compute(rnd_input)),
+        )
     end
 
     @testset "custom input validation and post processing" begin
         stp = TestSetupCustom()
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
-        
+
         @test QEDprocesses._is_valid_input(stp, _groundtruth_input_validation(rnd_input))
         @test !QEDprocesses._is_valid_input(stp, !_groundtruth_input_validation(rnd_input))
         @test_throws TestException() compute(stp, _transform_to_invalid(rnd_input))
-        @test isapprox(QEDprocesses._post_processing(stp,rnd_input,rnd_output), _groundtruth_post_processing(rnd_input,rnd_output))
-        @test isapprox(compute(stp,rnd_input), _groundtruth_post_processing(rnd_input,_groundtruth_compute(rnd_input)))
+        @test isapprox(
+            QEDprocesses._post_processing(stp, rnd_input, rnd_output),
+            _groundtruth_post_processing(rnd_input, rnd_output),
+        )
+        @test isapprox(
+            compute(stp, rnd_input),
+            _groundtruth_post_processing(rnd_input, _groundtruth_compute(rnd_input)),
+        )
     end
 end
 # process setup 
@@ -114,7 +153,7 @@ struct TestParticle2 <: AbstractParticle end
 struct TestParticle3 <: AbstractParticle end
 struct TestParticle4 <: AbstractParticle end
 
-PARTICLE_SET = [TestParticle1(), TestParticle2(), TestParticle3(),TestParticle4()]
+PARTICLE_SET = [TestParticle1(), TestParticle2(), TestParticle3(), TestParticle4()]
 
 struct TestProcess <: AbstractProcessDefinition end
 struct TestModel <: AbstractModelDefinition end
@@ -135,20 +174,21 @@ struct TestProcessSetupFAIL <: AbstractProcessSetup end
 
     @testset "hard interface" begin
         stp = TestProcessSetup()
-        
-        @test QEDprocesses._is_computation_setup(stp) 
+
+        @test QEDprocesses._is_computation_setup(stp)
         @test scattering_process(stp) == TestProcess()
         @test physical_model(stp) == TestModel()
     end
 
-    @testset "($N_INCOMING,$N_OUTGOING)" for (N_INCOMING,N_OUTGOING) in Iterators.product(
-                                                                                          (1, rand(RNG, 2:8)), (1, rand(RNG, 2:8))
-                                                                                         )   
-        INCOMING_PARTICLES = rand(RNG,PARTICLE_SET,N_INCOMING)
-        OUTGOING_PARTICLES = rand(RNG,PARTICLE_SET,N_OUTGOING)
+    @testset "($N_INCOMING,$N_OUTGOING)" for (N_INCOMING, N_OUTGOING) in Iterators.product(
+        (1, rand(RNG, 2:8)),
+        (1, rand(RNG, 2:8)),
+    )
+        INCOMING_PARTICLES = rand(RNG, PARTICLE_SET, N_INCOMING)
+        OUTGOING_PARTICLES = rand(RNG, PARTICLE_SET, N_OUTGOING)
 
         QEDprocesses.incoming_particles(::TestProcess) = INCOMING_PARTICLES
-        QEDprocesses.outgoing_particles(::TestProcess) = OUTGOING_PARTICLES 
+        QEDprocesses.outgoing_particles(::TestProcess) = OUTGOING_PARTICLES
 
         @testset "delegated functions" begin
             stp = TestProcessSetup()

--- a/test/interfaces/setup_interface.jl
+++ b/test/interfaces/setup_interface.jl
@@ -10,7 +10,7 @@ RTOL = sqrt(eps())
 _groundtruth_compute(x) = x
 _groundtruth_input_validation(x) = (x>0)
 _transform_to_invalid(x) = -abs(x)
-_groundtruth_post_computation(x,y) = x+y
+_groundtruth_post_processing(x,y) = x+y
 
 # setups for which the interface is implemented
 abstract type AbstractTestSetup <: AbstractComputationSetup end
@@ -32,14 +32,14 @@ function QEDprocesses._assert_valid_input(stp::TestSetupCustomAssertValidInput, 
     return nothing
 end 
 
-# setup with custom post computation
-struct TestSetupCustomPostComputation <: AbstractTestSetup end
-QEDprocesses._post_computation(::TestSetupCustomPostComputation,x,y) = _groundtruth_post_computation(x,y)
+# setup with custom post processing 
+struct TestSetupCustomPostProcessing<: AbstractTestSetup end
+QEDprocesses._post_processing(::TestSetupCustomPostProcessing,x,y) = _groundtruth_post_processing(x,y)
 
-# setup with custom input validation and post computation
+# setup with custom input validation and post processing 
 struct TestSetupCustom <: AbstractTestSetup end 
 QEDprocesses._is_valid_input(::TestSetupCustom, x) = _groundtruth_input_validation(x)
-QEDprocesses._post_computation(::TestSetupCustom,x,y) = _groundtruth_post_computation(x,y)
+QEDprocesses._post_processing(::TestSetupCustom,x,y) = _groundtruth_post_processing(x,y)
 
 # setup which fail on computation with default implementations
 struct TestSetupFAIL <: AbstractComputationSetup end
@@ -48,9 +48,9 @@ struct TestSetupFAIL <: AbstractComputationSetup end
 struct TestSetupCustomValidationFAIL <: AbstractComputationSetup end
 QEDprocesses._is_valid_input(::TestSetupCustomValidationFAIL, x) = _groundtruth_input_validation(x)
 
-# setup which fail on computation with custom post computation
-struct TestSetupCustomPostComputationFAIL <: AbstractComputationSetup end
-QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _groundtruth_post_computation(x,y)
+# setup which fail on computation with custom post processing
+struct TestSetupCustomPostProcessingFAIL <: AbstractComputationSetup end
+QEDprocesses._post_processing(::TestSetupCustomPostProcessingFAIL,x,y) = _groundtruth_post_processing(x,y)
 @testset "general computation setup interface" begin
     @testset "interface fail" begin
         rnd_input = rand(RNG)
@@ -62,8 +62,8 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
         # invalid input should be caught without throwing a MethodError
         @test_throws InvalidInputError compute(TestSetupCustomValidationFAIL(), _transform_to_invalid(rnd_input)) 
 
-        @test_throws MethodError QEDprocesses._compute(TestSetupCustomPostComputationFAIL(), rnd_input) 
-        @test_throws MethodError compute(TestSetupCustomPostComputationFAIL(), rnd_input) 
+        @test_throws MethodError QEDprocesses._compute(TestSetupCustomPostProcessingFAIL(), rnd_input) 
+        @test_throws MethodError compute(TestSetupCustomPostProcessingFAIL(), rnd_input) 
     end
 
     @testset "default interface" begin
@@ -72,7 +72,7 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
         @test QEDprocesses._is_valid_input(stp,rnd_input)
-        @test QEDprocesses._post_computation(stp,rnd_input,rnd_output) == rnd_output
+        @test QEDprocesses._post_processing(stp,rnd_input,rnd_output) == rnd_output
         @test isapprox(QEDprocesses._compute(stp, rnd_input), _groundtruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
         @test isapprox(compute(stp, rnd_input), _groundtruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
     end
@@ -94,15 +94,15 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
 
     end
 
-    @testset "custom post computation" begin
-        stp = TestSetupCustomPostComputation()
+    @testset "custom post processing" begin
+        stp = TestSetupCustomPostProcessing()
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
-        @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
-        @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundtruth_compute(rnd_input)))
+        @test isapprox(QEDprocesses._post_processing(stp,rnd_input,rnd_output), _groundtruth_post_processing(rnd_input,rnd_output))
+        @test isapprox(compute(stp,rnd_input), _groundtruth_post_processing(rnd_input,_groundtruth_compute(rnd_input)))
     end
 
-    @testset "custom input validation and post computation" begin
+    @testset "custom input validation and post processing" begin
         stp = TestSetupCustom()
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
@@ -110,8 +110,8 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
         @test QEDprocesses._is_valid_input(stp, _groundtruth_input_validation(rnd_input))
         @test !QEDprocesses._is_valid_input(stp, !_groundtruth_input_validation(rnd_input))
         @test_throws InvalidInputError compute(stp, _transform_to_invalid(rnd_input))
-        @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
-        @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundtruth_compute(rnd_input)))
+        @test isapprox(QEDprocesses._post_processing(stp,rnd_input,rnd_output), _groundtruth_post_processing(rnd_input,rnd_output))
+        @test isapprox(compute(stp,rnd_input), _groundtruth_post_processing(rnd_input,_groundtruth_compute(rnd_input)))
     end
 end
 # process setup 

--- a/test/interfaces/setup_interface.jl
+++ b/test/interfaces/setup_interface.jl
@@ -50,7 +50,7 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
 
         @test_throws MethodError QEDprocesses._compute(TestSetupCustomValidationFAIL(), rnd_input) 
         @test_throws MethodError compute(TestSetupCustomValidationFAIL(), rnd_input) 
-        # invalid input should be catched without throwing a MethodError
+        # invalid input should be caught without throwing a MethodError
         @test_throws ErrorException compute(TestSetupCustomValidationFAIL(), _transform_to_invalid(rnd_input)) 
 
         @test_throws MethodError QEDprocesses._compute(TestSetupCustomPostComputationFAIL(), rnd_input) 
@@ -138,7 +138,7 @@ struct TestProcessSetupFAIL <: AbstractProcessSetup end
         QEDprocesses.incoming_particles(::TestProcess) = INCOMING_PARTICLES
         QEDprocesses.outgoing_particles(::TestProcess) = OUTGOING_PARTICLES 
 
-        @testset "deligated functions" begin
+        @testset "delegated functions" begin
             stp = TestProcessSetup()
             @test number_incoming_particles(stp) == N_INCOMING
             @test number_outgoing_particles(stp) == N_OUTGOING

--- a/test/interfaces/setup_interface.jl
+++ b/test/interfaces/setup_interface.jl
@@ -134,8 +134,10 @@ struct TestProcessSetupFAIL <: AbstractProcessSetup end
 
 @testset "process setup interface" begin
     @testset "interface fail" begin
-        @test_throws MethodError scattering_process(TestProcessSetupFAIL)
-        @test_throws MethodError compute_model(TestProcessSetupFAIL)
+        rnd_input = rand(RNG)
+        @test_throws MethodError scattering_process(TestProcessSetupFAIL())
+        @test_throws MethodError compute_model(TestProcessSetupFAIL())
+        @test_throws MethodError QEDprocesses._compute(TestProcessSetupFAIL(), rnd_input)
     end
 
     @testset "hard interface" begin

--- a/test/interfaces/setup_interface.jl
+++ b/test/interfaces/setup_interface.jl
@@ -21,7 +21,7 @@ struct TestSetupDefault <: AbstractTestSetup end
 
 # setup with custom input validation
 struct TestSetupCustomValidation <: AbstractTestSetup end 
-QEDprocesses._input_validation(::TestSetupCustomValidation, x) = _groundthruth_input_validation(x)
+QEDprocesses._is_valid_input(::TestSetupCustomValidation, x) = _groundthruth_input_validation(x)
 
 # setup with custom post computation
 struct TestSetupCustomPostComputation <: AbstractTestSetup end
@@ -29,7 +29,7 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputation,x,y) = _groundtr
 
 # setup with custom input validation and post computation
 struct TestSetupCustom <: AbstractTestSetup end 
-QEDprocesses._input_validation(::TestSetupCustom, x) = _groundthruth_input_validation(x)
+QEDprocesses._is_valid_input(::TestSetupCustom, x) = _groundthruth_input_validation(x)
 QEDprocesses._post_computation(::TestSetupCustom,x,y) = _groundtruth_post_computation(x,y)
 
 # setup which fail on computation with default implementations
@@ -37,7 +37,7 @@ struct TestSetupFAIL <: AbstractComputationSetup end
 
 # setup which fail on computation with custom input validation
 struct TestSetupCustomValidationFAIL <: AbstractComputationSetup end
-QEDprocesses._input_validation(::TestSetupCustomValidationFAIL, x) = _groundthruth_input_validation(x)
+QEDprocesses._is_valid_input(::TestSetupCustomValidationFAIL, x) = _groundthruth_input_validation(x)
 
 # setup which fail on computation with custom post computation
 struct TestSetupCustomPostComputationFAIL <: AbstractComputationSetup end
@@ -62,7 +62,7 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
 
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
-        @test QEDprocesses._input_validation(stp,rnd_input)
+        @test QEDprocesses._is_valid_input(stp,rnd_input)
         @test QEDprocesses._post_computation(stp,rnd_input,rnd_output) == rnd_output
         @test isapprox(QEDprocesses._compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
         @test isapprox(compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
@@ -71,8 +71,8 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
     @testset "custom input validation" begin
         stp = TestSetupCustomValidation()
         rnd_input = rand(RNG)
-        @test QEDprocesses._input_validation(stp, _groundthruth_input_validation(rnd_input))
-        @test !QEDprocesses._input_validation(stp, !_groundthruth_input_validation(rnd_input))
+        @test QEDprocesses._is_valid_input(stp, _groundthruth_input_validation(rnd_input))
+        @test !QEDprocesses._is_valid_input(stp, !_groundthruth_input_validation(rnd_input))
         @test isapprox(compute(stp, rnd_input), _groundthruth_compute(rnd_input), atol=ATOL,rtol=RTOL)
         @test_throws ErrorException compute(stp, _transform_to_invalid(rnd_input))
     end
@@ -90,8 +90,8 @@ QEDprocesses._post_computation(::TestSetupCustomPostComputationFAIL,x,y) = _grou
         rnd_input = rand(RNG)
         rnd_output = rand(RNG)
 
-        @test QEDprocesses._input_validation(stp, _groundthruth_input_validation(rnd_input))
-        @test !QEDprocesses._input_validation(stp, !_groundthruth_input_validation(rnd_input))
+        @test QEDprocesses._is_valid_input(stp, _groundthruth_input_validation(rnd_input))
+        @test !QEDprocesses._is_valid_input(stp, !_groundthruth_input_validation(rnd_input))
         @test_throws ErrorException compute(stp, _transform_to_invalid(rnd_input))
         @test isapprox(QEDprocesses._post_computation(stp,rnd_input,rnd_output), _groundtruth_post_computation(rnd_input,rnd_output))
         @test isapprox(compute(stp,rnd_input), _groundtruth_post_computation(rnd_input,_groundthruth_compute(rnd_input)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,9 @@ begin
     @time @safetestset "process interface" begin
         include("interfaces/process_interface.jl")
     end
+    @time @safetestset "computation setup interface" begin 
+        include("interfaces/setup_interface.jl") 
+    end
 
     # modules
     @time @safetestset "particles types" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,8 +13,8 @@ begin
     @time @safetestset "process interface" begin
         include("interfaces/process_interface.jl")
     end
-    @time @safetestset "computation setup interface" begin 
-        include("interfaces/setup_interface.jl") 
+    @time @safetestset "computation setup interface" begin
+        include("interfaces/setup_interface.jl")
     end
 
     # modules


### PR DESCRIPTION
With this PR, the concept of *computation setups* is introduced, and general as well as functionality related to scattering processes is implemented. 

## Description of the problem

One of the main tasks of this package is the computation of quantities like differential and total cross-section for given scattering processes and a given set of parameters. Usually, these quantities depend on a fixed set of initial parameters, and their value needs to be calculated for large amounts of input data. For example, the differential cross-section of a process depends on the generic scattering process, the compute model, and all sorts of initial parameters, which might be physical (e.g. energy scales) or technical (e.g. integrator settings). Once initialized, the differential cross-section is still a function of the external momenta of a scattering process. Therefore, for a given set of input data, i.e. momenta, one needs to be able to compute the respective value of the differential cross-section using the given setting. 

## Suggested solution

The initial parameters for a given quantity will be collected in a *setup*, which, once initialized, describes the *initialized quantity*, i.e. the quantity with fixed initial parameters. The actual computation can be performed by calling a member function `compute` on the setup object and the respective input arguments. The implementation described below defines an interface, that unifies this approach and extends the computation workflow by adding input verification and post-processing steps. 

## Implementation details
The root type for all setups is `AbstractSetup`, for which the following interface functions are defined:

```Julia 
_input_validation(stp::AbstractSetup, input::Any)
_compute(stp::AbstractSetup, input::Any)
_post_computation(stp::AbstractSetup, input::Any, result::Any)
```

None of those functions is exported, but they need to be added for a concrete implementation of `AbstractSetup`. For all functions, except `_compute`, a generic fallback is implemented, which uses a default implementation for the respective function. Based on the interface functions, the actual compute function is implemented as 

```Julia

compute(stp::AbstractSetup, input::Any)

```
where internally, the following steps are performed:

1. input validation by calling `_input_validation` 
2. actual computation by calling `_compute`
3. post-processing by calling `_post_computation`

Additionally, based on `AbstractSetup`, a specialized version of setups related to the combination of scattering processes and compute models is implemented: `AbstractProcessSetup<:AbstractSetup`, where the following functions are added to the setup interface:

```Julia
scattering_process(stp::AbstractProcessSetup)
compute_model(stp::AbstractProcessSetup)
```

Based on them, the following functions are delegated to the respective type parameter:

```Julia
number_incoming_particles(stp::AbstractProcessSetup)
number_outgoing_particles(stp::AbstractProcessSetup)
```

## Final remarks

The possibilities for functionality based on the setup definition above are not exhausted by the set of interface functions defined with this PR. For example, the pre-and post-processing could be enhanced by more fine granular structures. Furthermore, the initialization step of a setup could have its input validation. This is currently delegated to the users, who implement a setup by themself. Finally, the set of functions defined on `AbstractProcessSetup` and delegated to the process and model, could be extended if necessary. However, all the points above should be considered only if they are necessary, which implies opening dedicated issues if any.
