### PR TITLE
Release v0.1.0 -- Add CHANGELOG to dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ This is the initial verison of QEDprocesses.
 
 
 ### Highlights
-* Particle interface (Particle types, fundamental properties) https://github.com/QEDjl-project/QEDprocesses.jl/pull/8
 * interface for scattering processes described by physical models (general properties, differential/total cross sections) https://github.com/QEDjl-project/QEDprocesses.jl/pull/11
+* interface for abstract setups (general computation setup and process dedicated
+setups) https://github.com/QEDjl-project/QEDprocesses.jl/pull/14
 * setup ci for unit and integration testing https://github.com/QEDjl-project/QEDprocesses.jl/pull/5 https://github.com/QEDjl-project/QEDprocesses.jl/pull/7 https://github.com/QEDjl-project/QEDprocesses.jl/pull/21
 * setup ci/cd for docs https://github.com/QEDjl-project/QEDprocesses.jl/pull/19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 This is the initial verison of QEDprocesses.
 
-[Diff scince inital commit](https://github.com/QEDjl-project/QEDprocesses.jl/compare/302274695d82225f4a810c252d6919839bc59fd7...release-v0.1.0) 
+[Diff since inital commit](https://github.com/QEDjl-project/QEDprocesses.jl/compare/302274695d82225f4a810c252d6919839bc59fd7...release-v0.1.0) 
 [Full list of PRs](https://github.com/QEDjl-project/QEDprocesses.jl/milestone/2?closed=1)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 This is the initial verison of QEDprocesses.
 
-[diff since latest main](https://github.com/QEDjl-project/QEDprocesses.jl/compare/302274695d82225f4a810c252d6919839bc59fd7...release-v0.1.0) [Full list of PRs](https://github.com/QEDjl-project/QEDprocesses.jl/milestone/2?closed=1)
+[Diff scince inital commit](https://github.com/QEDjl-project/QEDprocesses.jl/compare/302274695d82225f4a810c252d6919839bc59fd7...release-v0.1.0) 
+[Full list of PRs](https://github.com/QEDjl-project/QEDprocesses.jl/milestone/2?closed=1)
 
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## Version 0.1.0
 
-[diff since latest main](https://github.com/QEDjl-project/QEDprocesses.jl/compare/302274695d82225f4a810c252d6919839bc59fd7...release-v0.1.0)
-
-[Full list of PRs](https://github.com/QEDjl-project/QEDprocesses.jl/milestone/2?closed=1)
-
 This is the initial verison of QEDprocesses.
+
+[diff since latest main](https://github.com/QEDjl-project/QEDprocesses.jl/compare/302274695d82225f4a810c252d6919839bc59fd7...release-v0.1.0) [Full list of PRs](https://github.com/QEDjl-project/QEDprocesses.jl/milestone/2?closed=1)
+
 
 ### Highlights
 * Particle interface (Particle types, fundamental properties) https://github.com/QEDjl-project/QEDprocesses.jl/pull/8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## Version 0.1.0
+
+
+
+### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Changelog
 
+[diff since latest main](https://github.com/QEDjl-project/QEDprocesses.jl/compare/302274695d82225f4a810c252d6919839bc59fd7...release-v0.1.0)
+
+[Full list of PRs][https://github.com/QEDjl-project/QEDprocesses.jl/milestone/2?closed=1]
+
 ## Version 0.1.0
 
-
+This is the initial verison of QEDprocesses.
 
 ### Highlights
+* Particle interface (Particle types, fundamental properties) https://github.com/QEDjl-project/QEDprocesses.jl/pull/8
+* interface for scattering processes described by physical models (general properties, differential/total cross sections) https://github.com/QEDjl-project/QEDprocesses.jl/pull/11
+* setup ci for unit and integration testing https://github.com/QEDjl-project/QEDprocesses.jl/pull/5 https://github.com/QEDjl-project/QEDprocesses.jl/pull/7 https://github.com/QEDjl-project/QEDprocesses.jl/pull/21
+* setup ci/cd for docs https://github.com/QEDjl-project/QEDprocesses.jl/pull/19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [diff since latest main](https://github.com/QEDjl-project/QEDprocesses.jl/compare/302274695d82225f4a810c252d6919839bc59fd7...release-v0.1.0)
 
-[Full list of PRs][https://github.com/QEDjl-project/QEDprocesses.jl/milestone/2?closed=1]
+[Full list of PRs](https://github.com/QEDjl-project/QEDprocesses.jl/milestone/2?closed=1)
 
 ## Version 0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
+## Version 0.1.0
+
 [diff since latest main](https://github.com/QEDjl-project/QEDprocesses.jl/compare/302274695d82225f4a810c252d6919839bc59fd7...release-v0.1.0)
 
 [Full list of PRs](https://github.com/QEDjl-project/QEDprocesses.jl/milestone/2?closed=1)
-
-## Version 0.1.0
 
 This is the initial verison of QEDprocesses.
 


### PR DESCRIPTION
This PR add the CHANGELOG of the release of version `v0.1.0` to `dev`. 

Since this was already reviewed, it can be merged, if the checks all pass. 