### PR TITLE
Add PhaseSpacePoint definition

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 QEDbase = "0.1"

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -30,6 +30,7 @@ export propagator
 export AbstractCoordinateSystem, SphericalCoordinateSystem
 export AbstractFrameOfReference, CenterOfMomentumFrame, ElectronRestFrame
 export AbstractPhasespaceDefinition, PhasespaceDefinition
+export ParticleStateful, PhaseSpacePoint
 
 using QEDbase
 

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -31,6 +31,7 @@ export AbstractCoordinateSystem, SphericalCoordinateSystem
 export AbstractFrameOfReference, CenterOfMomentumFrame, ElectronRestFrame
 export AbstractPhasespaceDefinition, PhasespaceDefinition
 export ParticleStateful, PhaseSpacePoint
+export spin, pol
 
 using QEDbase
 

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -31,7 +31,7 @@ export AbstractCoordinateSystem, SphericalCoordinateSystem
 export AbstractFrameOfReference, CenterOfMomentumFrame, ElectronRestFrame
 export AbstractPhasespaceDefinition, PhasespaceDefinition
 export ParticleStateful, PhaseSpacePoint
-export spin, pol
+export spin, pol, nth_momentum, getindex
 
 using QEDbase
 

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -31,7 +31,7 @@ export AbstractCoordinateSystem, SphericalCoordinateSystem
 export AbstractFrameOfReference, CenterOfMomentumFrame, ElectronRestFrame
 export AbstractPhasespaceDefinition, PhasespaceDefinition
 export ParticleStateful, PhaseSpacePoint
-export spin, pol, nth_momentum, getindex
+export spin, polarization, momentum, getindex
 
 using QEDbase
 

--- a/src/interfaces/setup_interface.jl
+++ b/src/interfaces/setup_interface.jl
@@ -82,7 +82,7 @@ struct InvalidInputError <: AbstractInvalidInputException
     msg::String
 end
 function Base.showerror(io::IO, err::InvalidInputError)
-    return println(io, "InvalidInputError: $(err.msg).")
+    return println(io, "InvalidInputError: $(err.msg)")
 end
 
 """

--- a/src/phase_spaces.jl
+++ b/src/phase_spaces.jl
@@ -224,3 +224,11 @@ end
 @inline is_anti_particle(particle::ParticleStateful) = is_anti_particle(particle.species)
 @inline mass(particle::ParticleStateful) = mass(particle.species)
 @inline charge(particle::ParticleStateful) = charge(particle.species)
+
+@inline _spin(::Species, particle::ParticleStateful) where {Species<:FermionLike} =
+    particle.spin_or_pol
+@inline spin(particle::ParticleStateful) = _spin(particle.species, particle)
+
+@inline _pol(::Species, particle::ParticleStateful) where {Species<:BosonLike} =
+    particle.spin_or_pol
+@inline pol(particle::ParticleStateful) = _pol(particle.species, particle)

--- a/src/phase_spaces.jl
+++ b/src/phase_spaces.jl
@@ -15,6 +15,21 @@ import QEDbase.is_fermion
 import QEDbase.is_boson
 import QEDbase.is_incoming
 import QEDbase.is_outgoing
+import QEDbase.mass
+import QEDbase.charge
+
+import QEDbase:
+    is_particle,
+    is_anti_particle,
+    is_fermion,
+    is_boson,
+    is_incoming,
+    is_outgoing,
+    mass,
+    charge,
+    AbstractFourMomentum,
+    AbstractParticleType,
+    AbstractParticle
 
 abstract type AbstractCoordinateSystem end
 struct SphericalCoordinateSystem <: AbstractCoordinateSystem end
@@ -41,7 +56,7 @@ end
 #
 # Currently, elements can be either four-momenta, or real numbers,
 # i.e. coordinates.
-AbstractPhasespaceElement = Union{QEDbase.AbstractFourMomentum,Real}
+AbstractPhasespaceElement = Union{AbstractFourMomentum,Real}
 
 # utility functions 
 
@@ -49,7 +64,7 @@ AbstractPhasespaceElement = Union{QEDbase.AbstractFourMomentum,Real}
     proc::AbstractProcessDefinition,
     ::AbstractModelDefinition,
     in_phase_space::AbstractVecOrMat{T},
-) where {T<:QEDbase.AbstractFourMomentum}
+) where {T<:AbstractFourMomentum}
     return size(in_phase_space, 1) == number_incoming_particles(proc) || throw(
         DimensionMismatch(
             "The number of incoming particles <$(number_incoming_particles(proc))> is inconsistent with input size <$(size(in_phase_space,1))>",
@@ -61,7 +76,7 @@ end
     proc::AbstractProcessDefinition,
     ::AbstractModelDefinition,
     out_phase_space::AbstractVecOrMat{T},
-) where {T<:QEDbase.AbstractFourMomentum}
+) where {T<:AbstractFourMomentum}
     return size(out_phase_space, 1) == number_outgoing_particles(proc) || throw(
         DimensionMismatch(
             "The number of outgoing particles <$(number_outgoing_particles(proc))> is inconsistent with input size <$(size(out_phase_space,1))>",
@@ -94,45 +109,36 @@ end
 end
 
 """
-    ParticleStateful
+    ParticleStateful <: AbstractParticle
 
 Representation of a particle with a state. It has four fields:
-- `mom::AbstractPhasespaceElement`: The momentum of the particle.
-- `type::AbstractParticle`: The type of the particle, `QEDbase.Electron()`, `QEDbase.Positron()` etc..
-- `spinorpol::AbstractSpinOrPolarization`: The spin or polarization of the particle, `QEDbase.SpinUp()`, `QEDbase.PolX() etc.. Can only use spins with fermions and polarizations with bosons.
 - `dir::ParticleDirection`: The direction of the particle, `QEDbase.Incoming()` or `QEDbase.Outgoing()`.
+- `species::AbstractParticleType`: The species of the particle, `QEDbase.Electron()`, `QEDbase.Positron()` etc..
+- `mom::AbstractFourMomentum`: The momentum of the particle.
+- `spin_or_pol::AbstractSpinOrPolarization`: The spin or polarization of the particle, `QEDbase.SpinUp()`, `QEDbase.PolX() etc.. Can only use spins with fermions and polarizations with bosons.
 
-Overloads for `QEDbase.is_fermion`, `QEDbase.is_boson`, `QEDbase.is_particle`, `QEDbase.is_anti_particle`, `QEDbase.is_incoming`, and `QEDbase.is_outgoing` are provided, delegating the call to the correct field.
+Overloads for `QEDbase.is_fermion`, `QEDbase.is_boson`, `QEDbase.is_particle`, `QEDbase.is_anti_particle`, `QEDbase.is_incoming`, `QEDbase.is_outgoing`, `QEDbase.mass`, and `QEDbase.charge` are provided, delegating the call to the correct field and thus implementing the `QEDbase.AbstractParticle` interface.
 
 The legality of the combination of `type` and `spinorpol` is checked on construction. If, for example, the construction of an `Electron()` with a polarization is attempted, an [`InvalidInputError`](@ref) is thrown.
 """
-struct ParticleStateful{ElType<:AbstractPhasespaceElement}
-    mom::ElType
-    type::QEDbase.AbstractParticle
-    spinorpol::AbstractSpinOrPolarization
+struct ParticleStateful{ElType<:AbstractFourMomentum} <: AbstractParticle
     dir::ParticleDirection
+    species::AbstractParticleType
+    mom::ElType
+    spin_or_pol::AbstractSpinOrPolarization
 
     function ParticleStateful(
-        mom::ElType,
-        type::QEDbase.AbstractParticle,
-        spinorpol::AbstractSpinOrPolarization,
-        dir::ParticleDirection,
-    ) where {ElType<:AbstractPhasespaceElement}
-        if is_fermion(type) && !(spinorpol isa AbstractSpin)
-            throw(
-                InvalidInputError(
-                    "Tried to construct a stateful fermion with a $(spinorpol) instead of a spin",
-                ),
-            )
-        elseif is_boson(type) && !(spinorpol isa AbstractPolarization)
-            throw(
-                InvalidInputError(
-                    "Tried to construct a stateful boson with a $(spinorpol) instead of a polarization",
-                ),
-            )
-        end
+        dir::ParticleDirection, species::Species, mom::ElType, spin::Spin=AllSpin()
+    ) where {Species<:FermionLike,ElType<:AbstractFourMomentum,Spin<:AbstractSpin}
+        # constructor for fermions with spin
+        return new{ElType}(dir, species, mom, spin)
+    end
 
-        return new{ElType}(mom, type, spinorpol, dir)
+    function ParticleStateful(
+        dir::ParticleDirection, species::Species, mom::ElType, pol::Pol=AllPol()
+    ) where {Species<:BosonLike,ElType<:AbstractFourMomentum,Pol<:AbstractPolarization}
+        # constructor for bosons with polarization
+        return new{ElType}(dir, species, mom, pol)
     end
 end
 
@@ -147,7 +153,7 @@ struct PhaseSpacePoint{
     PROC<:AbstractProcessDefinition,
     MODEL<:AbstractModelDefinition,
     PSDEF<:AbstractPhasespaceDefinition,
-    PhaseSpaceElementType<:AbstractPhasespaceElement,
+    PhaseSpaceElementType<:AbstractFourMomentum,
     N_IN_PARTICLES,
     N_OUT_PARTICLES,
 }
@@ -164,7 +170,7 @@ struct PhaseSpacePoint{
         PROC<:AbstractProcessDefinition,
         MODEL<:AbstractModelDefinition,
         PSDEF<:AbstractPhasespaceDefinition,
-        PhaseSpaceElementType<:AbstractPhasespaceElement,
+        PhaseSpaceElementType<:AbstractFourMomentum,
         IN_P<:AbstractVector{ParticleStateful{PhaseSpaceElementType}},
         OUT_P<:AbstractVector{ParticleStateful{PhaseSpaceElementType}},
     }
@@ -180,9 +186,9 @@ struct PhaseSpacePoint{
         )
 
         for (proc_p, p) in zip(incoming_particles(proc), in_p)
-            proc_p == p.type || throw(
+            proc_p == p.species || throw(
                 InvalidInputError(
-                    "Process given particle type ($(proc_p)) does not match stateful particle type ($(p.type))",
+                    "Process given particle species ($(proc_p)) does not match stateful particle species ($(p.species))",
                 ),
             )
             is_incoming(p) || throw(
@@ -192,9 +198,9 @@ struct PhaseSpacePoint{
             )
         end
         for (proc_p, p) in zip(outgoing_particles(proc), out_p)
-            proc_p == p.type || throw(
+            proc_p == p.species || throw(
                 InvalidInputError(
-                    "Process given particle type ($(proc_p)) does not match stateful particle type ($(p.type))",
+                    "Process given particle species ($(proc_p)) does not match stateful particle species ($(p.species))",
                 ),
             )
             is_outgoing(p) || throw(
@@ -212,7 +218,9 @@ end
 
 @inline is_incoming(particle::ParticleStateful) = is_incoming(particle.dir)
 @inline is_outgoing(particle::ParticleStateful) = is_outgoing(particle.dir)
-@inline is_fermion(particle::ParticleStateful) = is_fermion(particle.type)
-@inline is_boson(particle::ParticleStateful) = is_boson(particle.type)
-@inline is_particle(particle::ParticleStateful) = is_particle(particle.type)
-@inline is_anti_particle(particle::ParticleStateful) = is_anti_particle(particle.type)
+@inline is_fermion(particle::ParticleStateful) = is_fermion(particle.species)
+@inline is_boson(particle::ParticleStateful) = is_boson(particle.species)
+@inline is_particle(particle::ParticleStateful) = is_particle(particle.species)
+@inline is_anti_particle(particle::ParticleStateful) = is_anti_particle(particle.species)
+@inline mass(particle::ParticleStateful) = mass(particle.species)
+@inline charge(particle::ParticleStateful) = charge(particle.species)

--- a/src/phase_spaces.jl
+++ b/src/phase_spaces.jl
@@ -155,9 +155,9 @@ end
     particle.spin_or_pol
 @inline spin(particle::ParticleStateful) = _spin(particle.species, particle)
 
-@inline _pol(::Species, particle::ParticleStateful) where {Species<:BosonLike} =
+@inline _polarization(::Species, particle::ParticleStateful) where {Species<:BosonLike} =
     particle.spin_or_pol
-@inline pol(particle::ParticleStateful) = _pol(particle.species, particle)
+@inline polarization(particle::ParticleStateful) = _polarization(particle.species, particle)
 
 """
     PhaseSpacePoint
@@ -252,10 +252,10 @@ function Base.getindex(psp::PhaseSpacePoint, ::Outgoing, n::Int)
 end
 
 """
-    nth_momentum(psp::PhaseSpacePoint, dir::ParticleDirection, n::Int)
+    momentum(psp::PhaseSpacePoint, dir::ParticleDirection, n::Int)
 
 Returns the momentum of the `n`th particle in the given [`PhaseSpacePoint`](@ref) which has direction `dir`. If `n` is outside the valid range for this phase space point, a `BoundsError` is thrown.
 """
-function nth_momentum(psp::PhaseSpacePoint, dir::ParticleDirection, n::Int)
+function momentum(psp::PhaseSpacePoint, dir::ParticleDirection, n::Int)
     return psp[dir, n].mom
 end

--- a/src/phase_spaces.jl
+++ b/src/phase_spaces.jl
@@ -113,13 +113,13 @@ end
 
 Representation of a particle with a state. It has four fields:
 - `dir::ParticleDirection`: The direction of the particle, `QEDbase.Incoming()` or `QEDbase.Outgoing()`.
-- `species::AbstractParticleType`: The species of the particle, `QEDbase.Electron()`, `QEDbase.Positron()` etc..
+- `species::AbstractParticleType`: The species of the particle, `QEDbase.Electron()`, `QEDbase.Positron()` etc.
 - `mom::AbstractFourMomentum`: The momentum of the particle.
-- `spin_or_pol::AbstractSpinOrPolarization`: The spin or polarization of the particle, `QEDbase.SpinUp()`, `QEDbase.PolX() etc.. Can only use spins with fermions and polarizations with bosons.
+- `spin_or_pol::AbstractSpinOrPolarization`: The spin or polarization of the particle, `QEDbase.SpinUp()`, `QEDbase.PolX() etc. Can only use spins with fermions and polarizations with bosons.
 
 Overloads for `QEDbase.is_fermion`, `QEDbase.is_boson`, `QEDbase.is_particle`, `QEDbase.is_anti_particle`, `QEDbase.is_incoming`, `QEDbase.is_outgoing`, `QEDbase.mass`, and `QEDbase.charge` are provided, delegating the call to the correct field and thus implementing the `QEDbase.AbstractParticle` interface.
 
-The legality of the combination of `type` and `spinorpol` is checked on construction. If, for example, the construction of an `Electron()` with a polarization is attempted, an [`InvalidInputError`](@ref) is thrown.
+The legality of the combination of `species` and `spin_or_pol` is checked on construction. If, for example, the construction of an `Electron()` with a polarization is attempted, an [`InvalidInputError`](@ref) is thrown.
 """
 struct ParticleStateful{ElType<:AbstractFourMomentum} <: AbstractParticle
     dir::ParticleDirection
@@ -164,7 +164,7 @@ end
 
 Representation of a point in the phase space of a process. Contains the process ([`AbstractProcessDefinition`](@ref)), the model ([`AbstractModelDefinition`](@ref)), the phase space definition ([`AbstractPhasespaceDefinition`]), and stateful incoming and outgoing particles ([`ParticleStateful`](@ref)).
 
-The legality of the combination of the given process and the incoming and outgoing particles is checked on construction. If the numbers of particles mismatch, the types of particles mismatch (note that order is important), or incoming particles have a `Outgoing` direction, an error is thrown.
+The legality of the combination of the given process and the incoming and outgoing particles is checked on construction. If the numbers of particles mismatch, the types of particles mismatch (note that order is important), or incoming particles have an `Outgoing` direction, an error is thrown.
 """
 struct PhaseSpacePoint{
     PROC<:AbstractProcessDefinition,
@@ -254,7 +254,7 @@ end
 """
     nth_momentum(psp::PhaseSpacePoint, dir::ParticleDirection, n::Int)
 
-Returns the momentum of the `n`th particle in the given [`PhaseSpacePoint`](@ref) which has direction `dir`. If `n` is outside the valid range for this phase space point, an `BoundsError` is thrown.
+Returns the momentum of the `n`th particle in the given [`PhaseSpacePoint`](@ref) which has direction `dir`. If `n` is outside the valid range for this phase space point, a `BoundsError` is thrown.
 """
 function nth_momentum(psp::PhaseSpacePoint, dir::ParticleDirection, n::Int)
     return psp[dir, n].mom

--- a/src/phase_spaces.jl
+++ b/src/phase_spaces.jl
@@ -67,7 +67,7 @@ AbstractPhasespaceElement = Union{AbstractFourMomentum,Real}
 ) where {T<:AbstractFourMomentum}
     return size(in_phase_space, 1) == number_incoming_particles(proc) || throw(
         DimensionMismatch(
-            "The number of incoming particles <$(number_incoming_particles(proc))> is inconsistent with input size <$(size(in_phase_space,1))>",
+            "the number of incoming particles <$(number_incoming_particles(proc))> is inconsistent with input size <$(size(in_phase_space,1))>",
         ),
     )
 end
@@ -79,7 +79,7 @@ end
 ) where {T<:AbstractFourMomentum}
     return size(out_phase_space, 1) == number_outgoing_particles(proc) || throw(
         DimensionMismatch(
-            "The number of outgoing particles <$(number_outgoing_particles(proc))> is inconsistent with input size <$(size(out_phase_space,1))>",
+            "the number of outgoing particles <$(number_outgoing_particles(proc))> is inconsistent with input size <$(size(out_phase_space,1))>",
         ),
     )
 end
@@ -91,7 +91,7 @@ end
 ) where {T<:Real}
     return size(in_phase_space, 1) == in_phase_space_dimension(proc, model) || throw(
         DimensionMismatch(
-            "The dimension of the in-phase-space <$(in_phase_space_dimension(proc,model))> is inconsistent with input size <$(size(in_phase_space,1))>",
+            "the dimension of the in-phase-space <$(in_phase_space_dimension(proc,model))> is inconsistent with input size <$(size(in_phase_space,1))>",
         ),
     )
 end
@@ -103,7 +103,7 @@ end
 ) where {T<:Real}
     return size(out_phase_space, 1) == out_phase_space_dimension(proc, model) || throw(
         DimensionMismatch(
-            "The dimension of the out-phase-space <$(out_phase_space_dimension(proc,model))> is inconsistent with input size <$(size(out_phase_space,1))>",
+            "the dimension of the out-phase-space <$(out_phase_space_dimension(proc,model))> is inconsistent with input size <$(size(out_phase_space,1))>",
         ),
     )
 end
@@ -193,36 +193,36 @@ struct PhaseSpacePoint{
     }
         length(incoming_particles(proc)) == length(in_p) || throw(
             InvalidInputError(
-                "The number of incoming particles given by the process ($(incoming_particles(proc))) mismatches the number of given stateful incoming particles ($(length(in_p)))",
+                "the number of incoming particles given by the process ($(incoming_particles(proc))) mismatches the number of given stateful incoming particles ($(length(in_p)))",
             ),
         )
         length(outgoing_particles(proc)) == length(out_p) || throw(
             InvalidInputError(
-                "The number of outgoing particles given by the process ($(outgoing_particles(proc))) mismatches the number of given stateful outgoing particles ($(length(out_p)))",
+                "the number of outgoing particles given by the process ($(outgoing_particles(proc))) mismatches the number of given stateful outgoing particles ($(length(out_p)))",
             ),
         )
 
         for (proc_p, p) in zip(incoming_particles(proc), in_p)
             proc_p == p.species || throw(
                 InvalidInputError(
-                    "Process given particle species ($(proc_p)) does not match stateful particle species ($(p.species))",
+                    "process given particle species ($(proc_p)) does not match stateful particle species ($(p.species))",
                 ),
             )
             is_incoming(p) || throw(
                 InvalidInputError(
-                    "Stateful particle $(p) is given as an incoming particle but is outgoing",
+                    "stateful particle $(p) is given as an incoming particle but is outgoing",
                 ),
             )
         end
         for (proc_p, p) in zip(outgoing_particles(proc), out_p)
             proc_p == p.species || throw(
                 InvalidInputError(
-                    "Process given particle species ($(proc_p)) does not match stateful particle species ($(p.species))",
+                    "process given particle species ($(proc_p)) does not match stateful particle species ($(p.species))",
                 ),
             )
             is_outgoing(p) || throw(
                 InvalidInputError(
-                    "Stateful particle $(p) is given as an outgoing particle but is incoming",
+                    "stateful particle $(p) is given as an outgoing particle but is incoming",
                 ),
             )
         end

--- a/src/phase_spaces.jl
+++ b/src/phase_spaces.jl
@@ -142,6 +142,23 @@ struct ParticleStateful{ElType<:AbstractFourMomentum} <: AbstractParticle
     end
 end
 
+@inline is_incoming(particle::ParticleStateful) = is_incoming(particle.dir)
+@inline is_outgoing(particle::ParticleStateful) = is_outgoing(particle.dir)
+@inline is_fermion(particle::ParticleStateful) = is_fermion(particle.species)
+@inline is_boson(particle::ParticleStateful) = is_boson(particle.species)
+@inline is_particle(particle::ParticleStateful) = is_particle(particle.species)
+@inline is_anti_particle(particle::ParticleStateful) = is_anti_particle(particle.species)
+@inline mass(particle::ParticleStateful) = mass(particle.species)
+@inline charge(particle::ParticleStateful) = charge(particle.species)
+
+@inline _spin(::Species, particle::ParticleStateful) where {Species<:FermionLike} =
+    particle.spin_or_pol
+@inline spin(particle::ParticleStateful) = _spin(particle.species, particle)
+
+@inline _pol(::Species, particle::ParticleStateful) where {Species<:BosonLike} =
+    particle.spin_or_pol
+@inline pol(particle::ParticleStateful) = _pol(particle.species, particle)
+
 """
     PhaseSpacePoint
 
@@ -216,19 +233,29 @@ struct PhaseSpacePoint{
     end
 end
 
-@inline is_incoming(particle::ParticleStateful) = is_incoming(particle.dir)
-@inline is_outgoing(particle::ParticleStateful) = is_outgoing(particle.dir)
-@inline is_fermion(particle::ParticleStateful) = is_fermion(particle.species)
-@inline is_boson(particle::ParticleStateful) = is_boson(particle.species)
-@inline is_particle(particle::ParticleStateful) = is_particle(particle.species)
-@inline is_anti_particle(particle::ParticleStateful) = is_anti_particle(particle.species)
-@inline mass(particle::ParticleStateful) = mass(particle.species)
-@inline charge(particle::ParticleStateful) = charge(particle.species)
+"""
+    Base.getindex(psp::PhaseSpacePoint, dir::Incoming, n::Int)
 
-@inline _spin(::Species, particle::ParticleStateful) where {Species<:FermionLike} =
-    particle.spin_or_pol
-@inline spin(particle::ParticleStateful) = _spin(particle.species, particle)
+Overload for the array indexing operator `[]`. Returns the nth incoming particle in this phase space point.
+"""
+function Base.getindex(psp::PhaseSpacePoint, ::Incoming, n::Int)
+    return psp.in_particles[n]
+end
 
-@inline _pol(::Species, particle::ParticleStateful) where {Species<:BosonLike} =
-    particle.spin_or_pol
-@inline pol(particle::ParticleStateful) = _pol(particle.species, particle)
+"""
+    Base.getindex(psp::PhaseSpacePoint, dir::Outgoing, n::Int)
+
+Overload for the array indexing operator `[]`. Returns the nth outgoing particle in this phase space point.
+"""
+function Base.getindex(psp::PhaseSpacePoint, ::Outgoing, n::Int)
+    return psp.out_particles[n]
+end
+
+"""
+    nth_momentum(psp::PhaseSpacePoint, dir::ParticleDirection, n::Int)
+
+Returns the momentum of the `n`th particle in the given [`PhaseSpacePoint`](@ref) which has direction `dir`. If `n` is outside the valid range for this phase space point, an `BoundsError` is thrown.
+"""
+function nth_momentum(psp::PhaseSpacePoint, dir::ParticleDirection, n::Int)
+    return psp[dir, n].mom
+end

--- a/src/phase_spaces.jl
+++ b/src/phase_spaces.jl
@@ -7,6 +7,15 @@
 # TODO: ship to interfaces!
 #####################
 
+using StaticArrays
+
+import QEDbase.is_particle
+import QEDbase.is_anti_particle
+import QEDbase.is_fermion
+import QEDbase.is_boson
+import QEDbase.is_incoming
+import QEDbase.is_outgoing
+
 abstract type AbstractCoordinateSystem end
 struct SphericalCoordinateSystem <: AbstractCoordinateSystem end
 
@@ -83,3 +92,66 @@ end
         ),
     )
 end
+
+"""
+    ParticleStateful
+
+Representation of a particle with a state. It has four fields:
+- `mom::AbstractPhasespaceElement`: The momentum of the particle.
+- `type::AbstractParticle`: The type of the particle, [`Electron`](@ref)(), [`Positron`](@ref)() etc..
+- `spinorpol::AbstractSpinOrPolarization`: The spin or polarization of the particle, [`SpinUp`](@ref)(), [`PolX`](@ref)() etc.. Can only use spins with fermions and polarizations with bosons.
+- `dir::ParticleDirection`: The direction of the particle, [`Incoming`](@ref)() or [`Outgoing`](@ref)().
+
+"""
+struct ParticleStateful{ElType<:AbstractPhasespaceElement}
+    mom::ElType
+    type::QEDbase.AbstractParticle
+    spinorpol::AbstractSpinOrPolarization
+    dir::ParticleDirection
+
+    function ParticleStateful(
+        mom::ElType,
+        type::QEDbase.AbstractParticle,
+        spinorpol::AbstractSpinOrPolarization,
+        dir::ParticleDirection,
+    ) where {ElType<:AbstractPhasespaceElement}
+        if is_fermion(type) && !(spinorpol isa AbstractSpin)
+            throw(
+                InvalidInputError(
+                    "Tried to construct a stateful fermion with a $(spinorpol) instead of a spin",
+                ),
+            )
+        elseif is_boson(type) && !(spinorpol isa AbstractPolarization)
+            throw(
+                InvalidInputError(
+                    "Tried to construct a stateful boson with a $(spinorpol) instead of a polarization",
+                ),
+            )
+        end
+
+        return new{ElType}(mom, type, spinorpol, dir)
+    end
+end
+
+struct PhaseSpacePoint{
+    PROC<:AbstractProcessDefinition,
+    MODEL<:AbstractModelDefinition,
+    PSDEF<:AbstractPhasespaceDefinition,
+    PhaseSpaceElementType<:AbstractPhasespaceElement,
+    N_IN_PARTICLES,
+    N_OUT_PARTICLES,
+}
+    proc::PROC
+    model::MODEL
+    ps_def::PSDEF
+
+    in_particles::SVector{N_IN_PARTICLES,ParticleStateful{PhaseSpaceElementType}}
+    out_particles::SVector{N_OUT_PARTICLES,ParticleStateful{PhaseSpaceElementType}}
+end
+
+@inline is_incoming(particle::ParticleStateful) = is_incoming(particle.dir)
+@inline is_outgoing(particle::ParticleStateful) = is_outgoing(particle.dir)
+@inline is_fermion(particle::ParticleStateful) = is_fermion(particle.type)
+@inline is_boson(particle::ParticleStateful) = is_boson(particle.type)
+@inline is_particle(particle::ParticleStateful) = is_particle(particle.type)
+@inline is_anti_particle(particle::ParticleStateful) = is_anti_particle(particle.type)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,5 +2,6 @@
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -72,7 +72,19 @@ end
     )
     phasespace_def = TESTPSDEF
 
-    PhaseSpacePoint(process, model, phasespace_def, in_particles_valid, out_particles_valid)
+    psp = PhaseSpacePoint(
+        process, model, phasespace_def, in_particles_valid, out_particles_valid
+    )
+
+    @test nth_momentum(psp, Incoming(), 1) == in_el.mom
+    @test nth_momentum(psp, Incoming(), 2) == in_ph.mom
+    @test nth_momentum(psp, Outgoing(), 1) == out_el.mom
+    @test nth_momentum(psp, Outgoing(), 2) == out_ph.mom
+
+    @test psp[Incoming(), 1] == in_el
+    @test psp[Incoming(), 2] == in_ph
+    @test psp[Outgoing(), 1] == out_el
+    @test psp[Outgoing(), 2] == out_ph
 
     if (VERSION >= v"1.8")
         # julia versions before 1.8 did not have support for regex matching in @test_throws
@@ -92,6 +104,16 @@ end
             process, model, phasespace_def, in_particles_valid, SVector(out_ph, out_el)
         )
     end
+
+    @test_throws BoundsError nth_momentum(psp, Incoming(), -1)
+    @test_throws BoundsError nth_momentum(psp, Outgoing(), -1)
+    @test_throws BoundsError nth_momentum(psp, Incoming(), 4)
+    @test_throws BoundsError nth_momentum(psp, Outgoing(), 4)
+
+    @test_throws BoundsError psp[Incoming(), -1]
+    @test_throws BoundsError psp[Outgoing(), -1]
+    @test_throws BoundsError psp[Incoming(), 4]
+    @test_throws BoundsError psp[Outgoing(), 4]
 
     @test_throws InvalidInputError PhaseSpacePoint(
         process, model, phasespace_def, in_particles_invalid, out_particles_valid

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -36,9 +36,9 @@ RNG = Random.MersenneTwister(727)
 
             if (is_fermion(species))
                 @test spin(particle_stateful) == spin_or_pol
-                @test_throws MethodError pol(particle_stateful)
+                @test_throws MethodError polarization(particle_stateful)
             else
-                @test pol(particle_stateful) == spin_or_pol
+                @test polarization(particle_stateful) == spin_or_pol
                 @test_throws MethodError spin(particle_stateful)
             end
         else
@@ -76,10 +76,10 @@ end
         process, model, phasespace_def, in_particles_valid, out_particles_valid
     )
 
-    @test nth_momentum(psp, Incoming(), 1) == in_el.mom
-    @test nth_momentum(psp, Incoming(), 2) == in_ph.mom
-    @test nth_momentum(psp, Outgoing(), 1) == out_el.mom
-    @test nth_momentum(psp, Outgoing(), 2) == out_ph.mom
+    @test momentum(psp, Incoming(), 1) == in_el.mom
+    @test momentum(psp, Incoming(), 2) == in_ph.mom
+    @test momentum(psp, Outgoing(), 1) == out_el.mom
+    @test momentum(psp, Outgoing(), 2) == out_ph.mom
 
     @test psp[Incoming(), 1] == in_el
     @test psp[Incoming(), 2] == in_ph
@@ -105,10 +105,10 @@ end
         )
     end
 
-    @test_throws BoundsError nth_momentum(psp, Incoming(), -1)
-    @test_throws BoundsError nth_momentum(psp, Outgoing(), -1)
-    @test_throws BoundsError nth_momentum(psp, Incoming(), 4)
-    @test_throws BoundsError nth_momentum(psp, Outgoing(), 4)
+    @test_throws BoundsError momentum(psp, Incoming(), -1)
+    @test_throws BoundsError momentum(psp, Outgoing(), -1)
+    @test_throws BoundsError momentum(psp, Incoming(), 4)
+    @test_throws BoundsError momentum(psp, Outgoing(), 4)
 
     @test_throws BoundsError psp[Incoming(), -1]
     @test_throws BoundsError psp[Outgoing(), -1]

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -10,13 +10,15 @@ include("test_implementation/TestImplementation.jl")
 TESTMODEL = TestImplementation.TestModel()
 TESTPSDEF = TestImplementation.TestPhasespaceDef()
 
+RNG = Random.MersenneTwister(727)
+
 @testset "Stateful Particle" begin
     DIRECTIONS = [Incoming(), Outgoing()]
     PARTICLES = [Electron(), Positron()] #=, Muon(), AntiMuon(), Tauon(), AntiTauon()=#
     SPINANDPOLS = [AllSpin(), SpinUp(), SpinDown(), AllPol(), PolX(), PolY()]
 
     for (particle, dir, spinorpol) in Iterators.product(PARTICLES, DIRECTIONS, SPINANDPOLS)
-        momentum = rand(SFourMomentum)
+        momentum = rand(RNG, SFourMomentum)
 
         if (is_fermion(particle) && (spinorpol isa AbstractSpin)) ||
             (is_boson(particle) && (spinorpol isa AbstractPolarization))
@@ -30,7 +32,13 @@ TESTPSDEF = TestImplementation.TestPhasespaceDef()
             @test is_incoming(particle_stateful) == is_incoming(dir)
             @test is_outgoing(particle_stateful) == is_outgoing(dir)
         else
-            @test_throws "Tried to construct a stateful $(is_fermion(particle) ? "fermion" : "boson") with a $(spinorpol) instead of a $(is_fermion(particle) ? "spin" : "polarization")" ParticleStateful(
+            if (VERSION >= v"1.8")
+                # julia versions before 1.8 did not have support for regex matching in @test_throws
+                @test_throws "Tried to construct a stateful $(is_fermion(particle) ? "fermion" : "boson") with a $(spinorpol) instead of a $(is_fermion(particle) ? "spin" : "polarization")" ParticleStateful(
+                    momentum, particle, spinorpol, dir
+                )
+            end
+            @test_throws InvalidInputError ParticleStateful(
                 momentum, particle, spinorpol, dir
             )
         end
@@ -38,10 +46,10 @@ TESTPSDEF = TestImplementation.TestPhasespaceDef()
 end
 
 @testset "Phasespace Point" begin
-    in_el = ParticleStateful(rand(SFourMomentum), Electron(), AllSpin(), Incoming())
-    in_ph = ParticleStateful(rand(SFourMomentum), Photon(), AllPol(), Incoming())
-    out_el = ParticleStateful(rand(SFourMomentum), Electron(), AllSpin(), Outgoing())
-    out_ph = ParticleStateful(rand(SFourMomentum), Photon(), AllPol(), Outgoing())
+    in_el = ParticleStateful(rand(RNG, SFourMomentum), Electron(), AllSpin(), Incoming())
+    in_ph = ParticleStateful(rand(RNG, SFourMomentum), Photon(), AllPol(), Incoming())
+    out_el = ParticleStateful(rand(RNG, SFourMomentum), Electron(), AllSpin(), Outgoing())
+    out_ph = ParticleStateful(rand(RNG, SFourMomentum), Photon(), AllPol(), Outgoing())
 
     in_particles_valid = SVector(in_el, in_ph)
     in_particles_invalid = SVector(in_el, out_ph)
@@ -58,19 +66,38 @@ end
 
     PhaseSpacePoint(process, model, phasespace_def, in_particles_valid, out_particles_valid)
 
-    @test_throws r"Stateful particle (.*) is given as an incoming particle but is outgoing" PhaseSpacePoint(
+    if (VERSION >= v"1.8")
+        # julia versions before 1.8 did not have support for regex matching in @test_throws
+        @test_throws r"Stateful particle (.*) is given as an incoming particle but is outgoing" PhaseSpacePoint(
+            process, model, phasespace_def, in_particles_invalid, out_particles_valid
+        )
+
+        @test_throws r"Stateful particle (.*) is given as an outgoing particle but is incoming" PhaseSpacePoint(
+            process, model, phasespace_def, in_particles_valid, out_particles_invalid
+        )
+
+        @test_throws r"Process given particle type \((.*)Electron\(\)\) does not match stateful particle type \((.*)Photon\(\)\)" PhaseSpacePoint(
+            process, model, phasespace_def, SVector(in_ph, in_el), out_particles_valid
+        )
+
+        @test_throws r"Process given particle type \((.*)Electron\(\)\) does not match stateful particle type \((.*)Photon\(\)\)" PhaseSpacePoint(
+            process, model, phasespace_def, in_particles_valid, SVector(out_ph, out_el)
+        )
+    end
+
+    @test_throws InvalidInputError PhaseSpacePoint(
         process, model, phasespace_def, in_particles_invalid, out_particles_valid
     )
 
-    @test_throws r"Stateful particle (.*) is given as an outgoing particle but is incoming" PhaseSpacePoint(
+    @test_throws InvalidInputError PhaseSpacePoint(
         process, model, phasespace_def, in_particles_valid, out_particles_invalid
     )
 
-    @test_throws r"Process given particle type \((.*)Electron\(\)\) does not match stateful particle type \((.*)Photon\(\)\)" PhaseSpacePoint(
+    @test_throws InvalidInputError PhaseSpacePoint(
         process, model, phasespace_def, SVector(in_ph, in_el), out_particles_valid
     )
 
-    @test_throws r"Process given particle type \((.*)Electron\(\)\) does not match stateful particle type \((.*)Photon\(\)\)" PhaseSpacePoint(
+    @test_throws InvalidInputError PhaseSpacePoint(
         process, model, phasespace_def, in_particles_valid, SVector(out_ph, out_el)
     )
 end

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -88,19 +88,19 @@ end
 
     if (VERSION >= v"1.8")
         # julia versions before 1.8 did not have support for regex matching in @test_throws
-        @test_throws r"Stateful particle (.*) is given as an incoming particle but is outgoing" PhaseSpacePoint(
+        @test_throws r"stateful particle (.*) is given as an incoming particle but is outgoing" PhaseSpacePoint(
             process, model, phasespace_def, in_particles_invalid, out_particles_valid
         )
 
-        @test_throws r"Stateful particle (.*) is given as an outgoing particle but is incoming" PhaseSpacePoint(
+        @test_throws r"stateful particle (.*) is given as an outgoing particle but is incoming" PhaseSpacePoint(
             process, model, phasespace_def, in_particles_valid, out_particles_invalid
         )
 
-        @test_throws r"Process given particle species \((.*)Electron\(\)\) does not match stateful particle species \((.*)Photon\(\)\)" PhaseSpacePoint(
+        @test_throws r"process given particle species \((.*)Electron\(\)\) does not match stateful particle species \((.*)Photon\(\)\)" PhaseSpacePoint(
             process, model, phasespace_def, SVector(in_ph, in_el), out_particles_valid
         )
 
-        @test_throws r"Process given particle species \((.*)Electron\(\)\) does not match stateful particle species \((.*)Photon\(\)\)" PhaseSpacePoint(
+        @test_throws r"process given particle species \((.*)Electron\(\)\) does not match stateful particle species \((.*)Photon\(\)\)" PhaseSpacePoint(
             process, model, phasespace_def, in_particles_valid, SVector(out_ph, out_el)
         )
     end

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -1,0 +1,33 @@
+using Random
+using QEDbase
+using QEDprocesses
+
+# can be removed when QEDbase exports them
+import QEDbase.is_incoming, QEDbase.is_outgoing
+
+@testset "Phasespace Point" begin
+    DIRECTIONS = [Incoming(), Outgoing()]
+    PARTICLES = [Electron(), Positron()] #=, Muon(), AntiMuon(), Tauon(), AntiTauon()=#
+    SPINANDPOLS = [AllSpin(), SpinUp(), SpinDown(), AllPol(), PolX(), PolY()]
+
+    for (particle, dir, spinorpol) in Iterators.product(PARTICLES, DIRECTIONS, SPINANDPOLS)
+        momentum = rand(SFourMomentum)
+
+        if (is_fermion(particle) && (spinorpol isa AbstractSpin)) ||
+            (is_boson(particle) && (spinorpol isa AbstractPolarization))
+            particle_stateful = ParticleStateful(momentum, particle, spinorpol, dir)
+
+            @test particle_stateful.mom == momentum
+            @test is_fermion(particle_stateful) == is_fermion(particle)
+            @test is_boson(particle_stateful) == is_boson(particle)
+            @test is_particle(particle_stateful) == is_particle(particle)
+            @test is_anti_particle(particle_stateful) == is_anti_particle(particle)
+            @test is_incoming(particle_stateful) == is_incoming(dir)
+            @test is_outgoing(particle_stateful) == is_outgoing(dir)
+        else
+            @test_throws "Tried to construct a stateful $(is_fermion(particle) ? "fermion" : "boson") with a $(spinorpol) instead of a $(is_fermion(particle) ? "spin" : "polarization")" ParticleStateful(
+                momentum, particle, spinorpol, dir
+            )
+        end
+    end
+end

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -1,11 +1,16 @@
 using Random
+using StaticArrays
 using QEDbase
 using QEDprocesses
 
 # can be removed when QEDbase exports them
 import QEDbase.is_incoming, QEDbase.is_outgoing
 
-@testset "Phasespace Point" begin
+include("test_implementation/TestImplementation.jl")
+TESTMODEL = TestImplementation.TestModel()
+TESTPSDEF = TestImplementation.TestPhasespaceDef()
+
+@testset "Stateful Particle" begin
     DIRECTIONS = [Incoming(), Outgoing()]
     PARTICLES = [Electron(), Positron()] #=, Muon(), AntiMuon(), Tauon(), AntiTauon()=#
     SPINANDPOLS = [AllSpin(), SpinUp(), SpinDown(), AllPol(), PolX(), PolY()]
@@ -30,4 +35,26 @@ import QEDbase.is_incoming, QEDbase.is_outgoing
             )
         end
     end
+end
+
+@testset "Phasespace Point" begin
+    in_el = ParticleStateful(rand(SFourMomentum), Electron(), AllSpin(), Incoming())
+    in_ph = ParticleStateful(rand(SFourMomentum), Photon(), AllPol(), Incoming())
+    out_el = ParticleStateful(rand(SFourMomentum), Electron(), AllSpin(), Outgoing())
+    out_ph = ParticleStateful(rand(SFourMomentum), Photon(), AllPol(), Outgoing())
+
+    in_particles_valid = SVector(in_el, in_ph)
+    in_particles_invalid = SVector(in_el, out_ph)
+
+    out_particles_valid = SVector(out_el, out_ph)
+    out_particles_invalid = SVector(out_el, in_ph)
+
+    model = TESTMODEL
+    process = TestImplementation.TestProcess(
+        SVector{2,AbstractParticle}(Electron(), Photon()),
+        SVector{2,AbstractParticle}(Electron(), Photon()),
+    )
+    phasespace_def = TESTPSDEF
+
+    PhaseSpacePoint(process, model, phasespace_def, in_particles_valid, out_particles_valid)
 end

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -57,4 +57,20 @@ end
     phasespace_def = TESTPSDEF
 
     PhaseSpacePoint(process, model, phasespace_def, in_particles_valid, out_particles_valid)
+
+    @test_throws r"Stateful particle (.*) is given as an incoming particle but is outgoing" PhaseSpacePoint(
+        process, model, phasespace_def, in_particles_invalid, out_particles_valid
+    )
+
+    @test_throws r"Stateful particle (.*) is given as an outgoing particle but is incoming" PhaseSpacePoint(
+        process, model, phasespace_def, in_particles_valid, out_particles_invalid
+    )
+
+    @test_throws r"Process given particle type \((.*)Electron\(\)\) does not match stateful particle type \((.*)Photon\(\)\)" PhaseSpacePoint(
+        process, model, phasespace_def, SVector(in_ph, in_el), out_particles_valid
+    )
+
+    @test_throws r"Process given particle type \((.*)Electron\(\)\) does not match stateful particle type \((.*)Photon\(\)\)" PhaseSpacePoint(
+        process, model, phasespace_def, in_particles_valid, SVector(out_ph, out_el)
+    )
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,4 +21,7 @@ begin
     @time @safetestset "cross section & probability" begin
         include("cross_sections.jl")
     end
+    @time @safetestset "phase spaces" begin
+        include("phase_spaces.jl")
+    end
 end


### PR DESCRIPTION
Proposal to fix issue #46

This branch is currently based on PR #39 and should be merged after it.

This is a draft for now, but I think it is a good compromise from the discussion in issue #46. The definition is type stable, allows some nice overloads for `is_fermion` and so on for the `ParticleStateful` objects, and takes care of preventing illegal objects in the constructors.


Creating particles is straightforward and disallows illegal configurations (electron with polarization or photon with spin):
```julia
in_el = ParticleStateful(rand(SFourMomentum), Electron(), AllSpin(), Incoming())
in_ph = ParticleStateful(rand(SFourMomentum), Photon(), AllPol(), Incoming())
out_el = ParticleStateful(rand(SFourMomentum), Electron(), AllSpin(), Outgoing())
out_ph = ParticleStateful(rand(SFourMomentum), Photon(), AllPol(), Outgoing())

in_particles_valid = SVector(in_el, in_ph)
in_particles_invalid = SVector(in_el, out_ph)

out_particles_valid = SVector(out_el, out_ph)
out_particles_invalid = SVector(out_el, in_ph)
```

Creating `PhaseSpacePoint`s is similarly simple and prevents illegal configurations, e.g. incoming particles in the outgoing list, but is still reasonably fast and does not need allocations. One PhaseSpacePoint for a 2 to 2 process is 944B in memory.
```julia
julia> @benchmark PhaseSpacePoint($process, $model, $phasespace_def, $in_particles_valid, $out_particles_valid)
BenchmarkTools.Trial: 10000 samples with 991 evaluations.
 Range (min … max):  39.268 ns … 111.740 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     41.068 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   43.116 ns ±   6.557 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

   ▃▇█▆▂ ▁▂▁▁                                             ▁    ▁
  ▆███████████▇▆▆▇▆▆▆▅▅▆▆▆▅▄▅▅▄▄▆▆▆▆▆▆▇▇▆▇▇█▇▅▄▅▅▄▅▄▅▄▅▆████▇▇ █
  39.3 ns       Histogram: log(frequency) by time      70.9 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

Suggestions welcome