### PR TITLE
added generate_phase_space and respective tests

### DIFF
--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -32,6 +32,7 @@ export AbstractFrameOfReference, CenterOfMomentumFrame, ElectronRestFrame
 export AbstractPhasespaceDefinition, PhasespaceDefinition
 export ParticleStateful, PhaseSpacePoint
 export spin, polarization, momentum, getindex
+export generate_phase_space
 
 using QEDbase
 

--- a/src/phase_spaces.jl
+++ b/src/phase_spaces.jl
@@ -259,3 +259,34 @@ Returns the momentum of the `n`th particle in the given [`PhaseSpacePoint`](@ref
 function momentum(psp::PhaseSpacePoint, dir::ParticleDirection, n::Int)
     return psp[dir, n].mom
 end
+
+"""
+
+    generate_phase_space(
+        proc::AbstractProcessDefinition, 
+        model::AbstractModelDefinition, 
+        ps_def::AbstractPhasespaceDefinition, 
+        in_ps::AbstractVector{ElType}, 
+        out_ps::AbstractVector{ElType},
+    ) where {ElType<:QEDbase.AbstractFourMomentum}
+
+Return the respective phase space point for given momenta of incoming and outgoing particles regarding a given process.
+"""
+function generate_phase_space(
+    proc::AbstractProcessDefinition, 
+    model::AbstractModelDefinition, 
+    ps_def::AbstractPhasespaceDefinition, 
+    in_ps::AbstractVector{ElType}, 
+    out_ps::AbstractVector{ElType},
+) where {ElType<:QEDbase.AbstractFourMomentum}
+    in_particles = incoming_particles(proc)
+    in_n = number_incoming_particles(proc)
+    in_parts = SVector{in_n,ParticleStateful{SFourMomentum}}(collect(ParticleStateful(Incoming(),particle,mom) for (particle,mom) in zip(in_particles,in_ps)))
+
+    out_particles = outgoing_particles(proc)
+    out_n = number_outgoing_particles(proc)
+    out_parts = SVector{out_n,ParticleStateful{SFourMomentum}}(collect(ParticleStateful(Outgoing(),particle,mom) for (particle,mom) in zip(out_particles,out_ps)))
+
+    return PhaseSpacePoint(proc,model,ps_def,in_parts,out_parts)
+end
+

--- a/src/phase_spaces.jl
+++ b/src/phase_spaces.jl
@@ -273,20 +273,29 @@ end
 Return the respective phase space point for given momenta of incoming and outgoing particles regarding a given process.
 """
 function generate_phase_space(
-    proc::AbstractProcessDefinition, 
-    model::AbstractModelDefinition, 
-    ps_def::AbstractPhasespaceDefinition, 
-    in_ps::AbstractVector{ElType}, 
+    proc::AbstractProcessDefinition,
+    model::AbstractModelDefinition,
+    ps_def::AbstractPhasespaceDefinition,
+    in_ps::AbstractVector{ElType},
     out_ps::AbstractVector{ElType},
 ) where {ElType<:QEDbase.AbstractFourMomentum}
     in_particles = incoming_particles(proc)
     in_n = number_incoming_particles(proc)
-    in_parts = SVector{in_n,ParticleStateful{SFourMomentum}}(collect(ParticleStateful(Incoming(),particle,mom) for (particle,mom) in zip(in_particles,in_ps)))
+    in_parts = SVector{in_n,ParticleStateful{SFourMomentum}}(
+        collect(
+            ParticleStateful(Incoming(), particle, mom) for
+            (particle, mom) in zip(in_particles, in_ps)
+        ),
+    )
 
     out_particles = outgoing_particles(proc)
     out_n = number_outgoing_particles(proc)
-    out_parts = SVector{out_n,ParticleStateful{SFourMomentum}}(collect(ParticleStateful(Outgoing(),particle,mom) for (particle,mom) in zip(out_particles,out_ps)))
+    out_parts = SVector{out_n,ParticleStateful{SFourMomentum}}(
+        collect(
+            ParticleStateful(Outgoing(), particle, mom) for
+            (particle, mom) in zip(out_particles, out_ps)
+        ),
+    )
 
-    return PhaseSpacePoint(proc,model,ps_def,in_parts,out_parts)
+    return PhaseSpacePoint(proc, model, ps_def, in_parts, out_parts)
 end
-

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -54,10 +54,16 @@ RNG = Random.MersenneTwister(727)
 end
 
 @testset "Phasespace Point" begin
-    in_el = ParticleStateful(Incoming(), Electron(), rand(RNG, SFourMomentum))
-    in_ph = ParticleStateful(Incoming(), Photon(), rand(RNG, SFourMomentum))
-    out_el = ParticleStateful(Outgoing(), Electron(), rand(RNG, SFourMomentum))
-    out_ph = ParticleStateful(Outgoing(), Photon(), rand(RNG, SFourMomentum))
+
+    in_el_mom = rand(RNG, SFourMomentum)
+    in_ph_mom = rand(RNG, SFourMomentum)
+    out_el_mom = rand(RNG, SFourMomentum)
+    out_ph_mom = rand(RNG, SFourMomentum)
+
+    in_el = ParticleStateful(Incoming(), Electron(),in_el_mom) 
+    in_ph = ParticleStateful(Incoming(), Photon(),in_ph_mom)
+    out_el = ParticleStateful(Outgoing(), Electron(), out_el_mom) 
+    out_ph = ParticleStateful(Outgoing(), Photon(), out_ph_mom) 
 
     in_particles_valid = SVector(in_el, in_ph)
     in_particles_invalid = SVector(in_el, out_ph)
@@ -76,58 +82,77 @@ end
         process, model, phasespace_def, in_particles_valid, out_particles_valid
     )
 
-    @test momentum(psp, Incoming(), 1) == in_el.mom
-    @test momentum(psp, Incoming(), 2) == in_ph.mom
-    @test momentum(psp, Outgoing(), 1) == out_el.mom
-    @test momentum(psp, Outgoing(), 2) == out_ph.mom
+    @testset "Accessor" begin 
+        @test momentum(psp, Incoming(), 1) == in_el.mom
+        @test momentum(psp, Incoming(), 2) == in_ph.mom
+        @test momentum(psp, Outgoing(), 1) == out_el.mom
+        @test momentum(psp, Outgoing(), 2) == out_ph.mom
 
-    @test psp[Incoming(), 1] == in_el
-    @test psp[Incoming(), 2] == in_ph
-    @test psp[Outgoing(), 1] == out_el
-    @test psp[Outgoing(), 2] == out_ph
+        @test psp[Incoming(), 1] == in_el
+        @test psp[Incoming(), 2] == in_ph
+        @test psp[Outgoing(), 1] == out_el
+        @test psp[Outgoing(), 2] == out_ph
+    end
 
-    if (VERSION >= v"1.8")
-        # julia versions before 1.8 did not have support for regex matching in @test_throws
-        @test_throws r"stateful particle (.*) is given as an incoming particle but is outgoing" PhaseSpacePoint(
+    @testset "Error handling" begin
+        if (VERSION >= v"1.8")
+            # julia versions before 1.8 did not have support for regex matching in @test_throws
+            @test_throws r"stateful particle (.*) is given as an incoming particle but is outgoing" PhaseSpacePoint(
+                process, model, phasespace_def, in_particles_invalid, out_particles_valid
+            )
+
+            @test_throws r"stateful particle (.*) is given as an outgoing particle but is incoming" PhaseSpacePoint(
+                process, model, phasespace_def, in_particles_valid, out_particles_invalid
+            )
+
+            @test_throws r"process given particle species \((.*)Electron\(\)\) does not match stateful particle species \((.*)Photon\(\)\)" PhaseSpacePoint(
+                process, model, phasespace_def, SVector(in_ph, in_el), out_particles_valid
+            )
+
+            @test_throws r"process given particle species \((.*)Electron\(\)\) does not match stateful particle species \((.*)Photon\(\)\)" PhaseSpacePoint(
+                process, model, phasespace_def, in_particles_valid, SVector(out_ph, out_el)
+            )
+        end
+
+        @test_throws BoundsError momentum(psp, Incoming(), -1)
+        @test_throws BoundsError momentum(psp, Outgoing(), -1)
+        @test_throws BoundsError momentum(psp, Incoming(), 4)
+        @test_throws BoundsError momentum(psp, Outgoing(), 4)
+
+        @test_throws BoundsError psp[Incoming(), -1]
+        @test_throws BoundsError psp[Outgoing(), -1]
+        @test_throws BoundsError psp[Incoming(), 4]
+        @test_throws BoundsError psp[Outgoing(), 4]
+
+        @test_throws InvalidInputError PhaseSpacePoint(
             process, model, phasespace_def, in_particles_invalid, out_particles_valid
         )
 
-        @test_throws r"stateful particle (.*) is given as an outgoing particle but is incoming" PhaseSpacePoint(
+        @test_throws InvalidInputError PhaseSpacePoint(
             process, model, phasespace_def, in_particles_valid, out_particles_invalid
         )
 
-        @test_throws r"process given particle species \((.*)Electron\(\)\) does not match stateful particle species \((.*)Photon\(\)\)" PhaseSpacePoint(
+        @test_throws InvalidInputError PhaseSpacePoint(
             process, model, phasespace_def, SVector(in_ph, in_el), out_particles_valid
         )
 
-        @test_throws r"process given particle species \((.*)Electron\(\)\) does not match stateful particle species \((.*)Photon\(\)\)" PhaseSpacePoint(
+        @test_throws InvalidInputError PhaseSpacePoint(
             process, model, phasespace_def, in_particles_valid, SVector(out_ph, out_el)
         )
     end
 
-    @test_throws BoundsError momentum(psp, Incoming(), -1)
-    @test_throws BoundsError momentum(psp, Outgoing(), -1)
-    @test_throws BoundsError momentum(psp, Incoming(), 4)
-    @test_throws BoundsError momentum(psp, Outgoing(), 4)
+    @testset "Generation" begin
+        test_psp = generate_phase_space(process,model,phasespace_def,[in_el_mom,in_ph_mom],[out_el_mom,out_ph_mom])
 
-    @test_throws BoundsError psp[Incoming(), -1]
-    @test_throws BoundsError psp[Outgoing(), -1]
-    @test_throws BoundsError psp[Incoming(), 4]
-    @test_throws BoundsError psp[Outgoing(), 4]
+        @test test_psp.proc == process
+        @test test_psp.model == model
+        @test test_psp.ps_def == phasespace_def
+    
+        @test test_psp[Incoming(),1] == in_el
+        @test test_psp[Incoming(),2] == in_ph
+        @test test_psp[Outgoing(),1] == out_el
+        @test test_psp[Outgoing(),2] == out_ph
 
-    @test_throws InvalidInputError PhaseSpacePoint(
-        process, model, phasespace_def, in_particles_invalid, out_particles_valid
-    )
+    end
 
-    @test_throws InvalidInputError PhaseSpacePoint(
-        process, model, phasespace_def, in_particles_valid, out_particles_invalid
-    )
-
-    @test_throws InvalidInputError PhaseSpacePoint(
-        process, model, phasespace_def, SVector(in_ph, in_el), out_particles_valid
-    )
-
-    @test_throws InvalidInputError PhaseSpacePoint(
-        process, model, phasespace_def, in_particles_valid, SVector(out_ph, out_el)
-    )
 end

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -54,16 +54,15 @@ RNG = Random.MersenneTwister(727)
 end
 
 @testset "Phasespace Point" begin
-
     in_el_mom = rand(RNG, SFourMomentum)
     in_ph_mom = rand(RNG, SFourMomentum)
     out_el_mom = rand(RNG, SFourMomentum)
     out_ph_mom = rand(RNG, SFourMomentum)
 
-    in_el = ParticleStateful(Incoming(), Electron(),in_el_mom) 
-    in_ph = ParticleStateful(Incoming(), Photon(),in_ph_mom)
-    out_el = ParticleStateful(Outgoing(), Electron(), out_el_mom) 
-    out_ph = ParticleStateful(Outgoing(), Photon(), out_ph_mom) 
+    in_el = ParticleStateful(Incoming(), Electron(), in_el_mom)
+    in_ph = ParticleStateful(Incoming(), Photon(), in_ph_mom)
+    out_el = ParticleStateful(Outgoing(), Electron(), out_el_mom)
+    out_ph = ParticleStateful(Outgoing(), Photon(), out_ph_mom)
 
     in_particles_valid = SVector(in_el, in_ph)
     in_particles_invalid = SVector(in_el, out_ph)
@@ -82,7 +81,7 @@ end
         process, model, phasespace_def, in_particles_valid, out_particles_valid
     )
 
-    @testset "Accessor" begin 
+    @testset "Accessor" begin
         @test momentum(psp, Incoming(), 1) == in_el.mom
         @test momentum(psp, Incoming(), 2) == in_ph.mom
         @test momentum(psp, Outgoing(), 1) == out_el.mom
@@ -142,17 +141,17 @@ end
     end
 
     @testset "Generation" begin
-        test_psp = generate_phase_space(process,model,phasespace_def,[in_el_mom,in_ph_mom],[out_el_mom,out_ph_mom])
+        test_psp = generate_phase_space(
+            process, model, phasespace_def, [in_el_mom, in_ph_mom], [out_el_mom, out_ph_mom]
+        )
 
         @test test_psp.proc == process
         @test test_psp.model == model
         @test test_psp.ps_def == phasespace_def
-    
-        @test test_psp[Incoming(),1] == in_el
-        @test test_psp[Incoming(),2] == in_ph
-        @test test_psp[Outgoing(),1] == out_el
-        @test test_psp[Outgoing(),2] == out_ph
 
+        @test test_psp[Incoming(), 1] == in_el
+        @test test_psp[Incoming(), 2] == in_ph
+        @test test_psp[Outgoing(), 1] == out_el
+        @test test_psp[Outgoing(), 2] == out_ph
     end
-
 end


### PR DESCRIPTION
This adds a little convenient function `generate_phase_space` to build the new phase space points from a given process, model, phase-space definition, and lists of four-momenta for incoming and outgoing particles.