### PR TITLE
Moved test deps to main Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,12 @@
 name = "QEDprocesses"
 uuid = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
-authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
+authors = [
+    "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
+    "Simeon Ehrig",
+    "Klaus Steiniger",
+    "Tom Jungnickel",
+    "Anton Reinhard",
+]
 version = "0.1.0"
 
 [deps]
@@ -12,3 +18,12 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 QEDbase = "0.1"
 StaticArrays = "1"
 julia = "1.6"
+
+[extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Random", "SafeTestsets", "Suppressor", "Test"]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,0 @@
-[deps]
-QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
-QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/cross_sections.jl
+++ b/test/cross_sections.jl
@@ -1,5 +1,4 @@
 using Random
-using Suppressor
 using QEDbase
 using QEDprocesses
 

--- a/test/interfaces/process_interface.jl
+++ b/test/interfaces/process_interface.jl
@@ -1,5 +1,4 @@
 using Random
-using Suppressor
 using QEDbase
 using QEDprocesses
 


### PR DESCRIPTION
As the title says, this moves the test dependencies from `test/Project.toml` to the main `Project.toml`. To not mix these with the package dependencies, we use the `[extras]` and `[target]` blocks. 

This keeps the dependencies of the package incl. tests in one place and makes maintenance easier. Furthermore, it allows testing locally against unreleased branches of a package dependency, because the package and the tests use the same `Manifest.toml`.