### PR TITLE
Refactoring QED.jl

### DIFF
--- a/.github/workflows/BuildDeployDoc.yml
+++ b/.github/workflows/BuildDeployDoc.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - dev
-    tags: '*'
+    tags: "*"
   pull_request:
 
 jobs:
@@ -18,9 +18,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.9'
+          version: "1.9"
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: |
+          julia --project=docs/ add_QEDcore_dev.jl
+          julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,7 @@ stages:
   script:
     - apt update && apt install -y git
     - git clone --depth 1 -b dev https://github.com/QEDjl-project/QED.jl.git /QEDjl
+    - julia --project=. add_QEDcore_dev.jl
     - >
       if [[ $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_REF_NAME == "dev" ]]; then
         # set name of the commit message from CI_COMMIT_MESSAGE to NO_MESSAGE, that the script does not read accidentally custom packages from the commit message of a merge commit

--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,11 @@
 name = "QEDprocesses"
 uuid = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
-authors = [
-    "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
-    "Simeon Ehrig",
-    "Klaus Steiniger",
-    "Tom Jungnickel",
-    "Anton Reinhard",
-]
+authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
 version = "0.1.0"
 
 [deps]
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
+QEDcore = "35dc0263-cb5f-4c33-a114-1d7f54ab753e"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 

--- a/add_QEDcore_dev.jl
+++ b/add_QEDcore_dev.jl
@@ -1,0 +1,5 @@
+
+@warn "This repository depends on the dev branch of QEDcore.jl\n It is NOT ready for release!"
+
+using Pkg: Pkg
+Pkg.add(; url="https://github.com/QEDjl-project/QEDcore.jl", rev="dev")

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -44,7 +44,7 @@ export PerturbativeQED
 # specific scattering processes
 export Compton, omega_prime
 
-import QEDbase
+using QEDbase: QEDbase
 using QEDcore
 using StaticArrays
 using QuadGK

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -44,9 +44,12 @@ export PerturbativeQED
 # specific scattering processes
 export Compton, omega_prime
 
-using QEDbase
+import QEDbase
+using QEDcore
 using StaticArrays
 using QuadGK
+
+include("restruct_patch.jl")
 
 include("constants.jl")
 include("utils.jl")

--- a/src/cross_section/diff_probability.jl
+++ b/src/cross_section/diff_probability.jl
@@ -35,7 +35,7 @@ If the given phase spaces are physical, return differential probability evaluate
 """
 function differential_probability(phase_space_point::PhaseSpacePoint)
     if !_is_in_phasespace(phase_space_point)
-        return zero(eltype(momentum(phase_space_point, Incoming(), 1)))
+        return zero(eltype(momentum(phase_space_point, QEDbase.Incoming(), 1)))
     end
 
     return unsafe_differential_probability(phase_space_point)

--- a/src/interfaces/process_interface.jl
+++ b/src/interfaces/process_interface.jl
@@ -155,9 +155,9 @@ end
 
 Convenience function dispatching to [`incoming_particles`](@ref) or [`outgoing_particles`](@ref) depending on the given direction.
 """
-@inline particles(proc_def::AbstractProcessDefinition, ::Incoming) =
+@inline particles(proc_def::AbstractProcessDefinition, ::QEDbase.Incoming) =
     incoming_particles(proc_def)
-@inline particles(proc_def::AbstractProcessDefinition, ::Outgoing) =
+@inline particles(proc_def::AbstractProcessDefinition, ::QEDbase.Outgoing) =
     outgoing_particles(proc_def)
 
 """
@@ -165,9 +165,9 @@ Convenience function dispatching to [`incoming_particles`](@ref) or [`outgoing_p
 
 Convenience function dispatching to [`number_incoming_particles`](@ref) or [`number_outgoing_particles`](@ref) depending on the given direction.
 """
-@inline number_particles(proc_def::AbstractProcessDefinition, ::Incoming) =
+@inline number_particles(proc_def::AbstractProcessDefinition, ::QEDbase.Incoming) =
     number_incoming_particles(proc_def)
-@inline number_particles(proc_def::AbstractProcessDefinition, ::Outgoing) =
+@inline number_particles(proc_def::AbstractProcessDefinition, ::QEDbase.Outgoing) =
     number_outgoing_particles(proc_def)
 
 """

--- a/src/patch_QEDbase.jl
+++ b/src/patch_QEDbase.jl
@@ -5,26 +5,26 @@
 #############
 
 # fix: https://github.com/QEDjl-project/QEDbase.jl/pull/61
-Base.show(io::IO, ::Electron) = print(io, "electron")
-Base.show(io::IO, ::Positron) = print(io, "positron")
-Base.show(io::IO, ::Photon) = print(io, "photon")
-Base.show(io::IO, ::Incoming) = print(io, "incoming")
-Base.show(io::IO, ::Outgoing) = print(io, "outgoing")
-Base.show(io::IO, ::PolX) = print(io, "x-polarized")
-Base.show(io::IO, ::PolY) = print(io, "y-polarized")
-Base.show(io::IO, ::AllPol) = print(io, "all polarizations")
-Base.show(io::IO, ::SpinUp) = print(io, "spin up")
-Base.show(io::IO, ::SpinDown) = print(io, "spin down")
-Base.show(io::IO, ::AllSpin) = print(io, "all spins")
+Base.show(io::IO, ::QEDbase.Electron) = print(io, "electron")
+Base.show(io::IO, ::QEDbase.Positron) = print(io, "positron")
+Base.show(io::IO, ::QEDbase.Photon) = print(io, "photon")
+Base.show(io::IO, ::QEDbase.Incoming) = print(io, "incoming")
+Base.show(io::IO, ::QEDbase.Outgoing) = print(io, "outgoing")
+Base.show(io::IO, ::QEDbase.PolX) = print(io, "x-polarized")
+Base.show(io::IO, ::QEDbase.PolY) = print(io, "y-polarized")
+Base.show(io::IO, ::QEDbase.AllPol) = print(io, "all polarizations")
+Base.show(io::IO, ::QEDbase.SpinUp) = print(io, "spin up")
+Base.show(io::IO, ::QEDbase.SpinDown) = print(io, "spin down")
+Base.show(io::IO, ::QEDbase.AllSpin) = print(io, "all spins")
 
 # fix: https://github.com/QEDjl-project/QEDbase.jl/pull/62
-Broadcast.broadcastable(dir::Incoming) = Ref(dir)
-Broadcast.broadcastable(dir::Outgoing) = Ref(dir)
-Broadcast.broadcastable(part::AbstractParticleType) = Ref(part)
-Broadcast.broadcastable(spin_or_pol::AbstractSpinOrPolarization) = Ref(spin_or_pol)
+Broadcast.broadcastable(dir::QEDbase.Incoming) = Ref(dir)
+Broadcast.broadcastable(dir::QEDbase.Outgoing) = Ref(dir)
+Broadcast.broadcastable(part::QEDbase.AbstractParticleType) = Ref(part)
+Broadcast.broadcastable(spin_or_pol::QEDbase.AbstractSpinOrPolarization) = Ref(spin_or_pol)
 
 # fix: https://github.com/QEDjl-project/QEDbase.jl/pull/63
-number_of_spin_pol(::AbstractDefinitePolarization) = 1
-number_of_spin_pol(::AbstractDefiniteSpin) = 1
-number_of_spin_pol(::AbstractIndefinitePolarization) = 2
-number_of_spin_pol(::AbstractIndefiniteSpin) = 2
+number_of_spin_pol(::QEDbase.AbstractDefinitePolarization) = 1
+number_of_spin_pol(::QEDbase.AbstractDefiniteSpin) = 1
+number_of_spin_pol(::QEDbase.AbstractIndefinitePolarization) = 2
+number_of_spin_pol(::QEDbase.AbstractIndefiniteSpin) = 2

--- a/src/phase_spaces/access.jl
+++ b/src/phase_spaces/access.jl
@@ -28,15 +28,15 @@ momentum(part::ParticleStateful) = part.mom
 
 Return a `Tuple` of all the particles' momenta for the given `ParticleDirection`.
 """
-momenta(psp::PhaseSpacePoint, ::Incoming) = momentum.(psp.in_particles)
-momenta(psp::PhaseSpacePoint, ::Outgoing) = momentum.(psp.out_particles)
+momenta(psp::PhaseSpacePoint, ::QEDbase.Incoming) = momentum.(psp.in_particles)
+momenta(psp::PhaseSpacePoint, ::QEDbase.Outgoing) = momentum.(psp.out_particles)
 
 """
     Base.getindex(psp::PhaseSpacePoint, dir::Incoming, n::Int)
 
 Overload for the array indexing operator `[]`. Returns the nth incoming particle in this phase space point.
 """
-function Base.getindex(psp::PhaseSpacePoint, ::Incoming, n::Int)
+function Base.getindex(psp::PhaseSpacePoint, ::QEDbase.Incoming, n::Int)
     return psp.in_particles[n]
 end
 
@@ -45,7 +45,7 @@ end
 
 Overload for the array indexing operator `[]`. Returns the nth outgoing particle in this phase space point.
 """
-function Base.getindex(psp::PhaseSpacePoint, ::Outgoing, n::Int)
+function Base.getindex(psp::PhaseSpacePoint, ::QEDbase.Outgoing, n::Int)
     return psp.out_particles[n]
 end
 
@@ -54,6 +54,6 @@ end
 
 Returns the momentum of the `n`th particle in the given [`PhaseSpacePoint`](@ref) which has direction `dir`. If `n` is outside the valid range for this phase space point, a `BoundsError` is thrown.
 """
-function momentum(psp::PhaseSpacePoint, dir::ParticleDirection, n::Int)
+function momentum(psp::PhaseSpacePoint, dir::QEDbase.ParticleDirection, n::Int)
     return psp[dir, n].mom
 end

--- a/src/phase_spaces/create.jl
+++ b/src/phase_spaces/create.jl
@@ -62,8 +62,8 @@ function PhaseSpacePoint(
     in_momenta::NTuple{N,ELEMENT},
     out_momenta::NTuple{M,ELEMENT},
 ) where {N,M,ELEMENT<:QEDbase.AbstractFourMomentum}
-    in_particles = _build_particle_statefuls(proc, in_momenta, Incoming())
-    out_particles = _build_particle_statefuls(proc, out_momenta, Outgoing())
+    in_particles = _build_particle_statefuls(proc, in_momenta, QEDbase.Incoming())
+    out_particles = _build_particle_statefuls(proc, out_momenta, QEDbase.Outgoing())
 
     return PhaseSpacePoint(proc, model, ps_def, in_particles, out_particles)
 end
@@ -84,7 +84,7 @@ function InPhaseSpacePoint(
     ps_def::AbstractPhasespaceDefinition,
     in_momenta::NTuple{N,ELEMENT},
 ) where {N,ELEMENT<:QEDbase.AbstractFourMomentum}
-    in_particles = _build_particle_statefuls(proc, in_momenta, Incoming())
+    in_particles = _build_particle_statefuls(proc, in_momenta, QEDbase.Incoming())
 
     return PhaseSpacePoint(proc, model, ps_def, in_particles, ())
 end
@@ -105,7 +105,7 @@ function OutPhaseSpacePoint(
     ps_def::AbstractPhasespaceDefinition,
     out_momenta::NTuple{N,ELEMENT},
 ) where {N,ELEMENT<:QEDbase.AbstractFourMomentum}
-    out_particles = _build_particle_statefuls(proc, out_momenta, Outgoing())
+    out_particles = _build_particle_statefuls(proc, out_momenta, QEDbase.Outgoing())
 
     return PhaseSpacePoint(proc, model, ps_def, (), out_particles)
 end

--- a/src/phase_spaces/types.jl
+++ b/src/phase_spaces/types.jl
@@ -49,10 +49,10 @@ ParticleStateful: outgoing photon
 ```
 """
 struct ParticleStateful{
-    DIR<:ParticleDirection,
-    SPECIES<:AbstractParticleType,
+    DIR<:QEDbase.ParticleDirection,
+    SPECIES<:QEDbase.AbstractParticleType,
     ELEMENT<:QEDbase.AbstractFourMomentum,
-} <: AbstractParticle
+} <: QEDbase.AbstractParticle
     dir::DIR
     species::SPECIES
     mom::ELEMENT
@@ -60,8 +60,8 @@ struct ParticleStateful{
     function ParticleStateful(
         dir::DIR, species::SPECIES, mom::ELEMENT
     ) where {
-        DIR<:ParticleDirection,
-        SPECIES<:AbstractParticleType,
+        DIR<:QEDbase.ParticleDirection,
+        SPECIES<:QEDbase.AbstractParticleType,
         ELEMENT<:QEDbase.AbstractFourMomentum,
     }
         return new{DIR,SPECIES,ELEMENT}(dir, species, mom)
@@ -76,19 +76,19 @@ Representation of a point in the phase space of a process. Contains the process 
 The legality of the combination of the given process and the incoming and outgoing particles is checked on construction. If the numbers of particles mismatch, the types of particles mismatch (note that order is important), or incoming particles have an `Outgoing` direction, an error is thrown.
 
 ```jldoctest
-julia> using QEDprocesses; using QEDbase
+julia> using QEDprocesses; import QEDbase; using QEDcore
 
 julia> PhaseSpacePoint(
             Compton(), 
             PerturbativeQED(), 
             PhasespaceDefinition(SphericalCoordinateSystem(), ElectronRestFrame()), 
             (
-                ParticleStateful(Incoming(), Electron(), SFourMomentum(1, 0, 0, 0)), 
-                ParticleStateful(Incoming(), Photon(), SFourMomentum(1, 0, 0, 0))
+                ParticleStateful(QEDbase.Incoming(), QEDbase.Electron(), SFourMomentum(1, 0, 0, 0)), 
+                ParticleStateful(QEDbase.Incoming(), QEDbase.Photon(), SFourMomentum(1, 0, 0, 0))
             ), 
             (
-                ParticleStateful(Outgoing(), Electron(), SFourMomentum(1, 0, 0, 0)), 
-                ParticleStateful(Outgoing(), Photon(), SFourMomentum(1, 0, 0, 0))
+                ParticleStateful(QEDbase.Outgoing(), QEDbase.Electron(), SFourMomentum(1, 0, 0, 0)), 
+                ParticleStateful(QEDbase.Outgoing(), QEDbase.Photon(), SFourMomentum(1, 0, 0, 0))
             )
         )
 PhaseSpacePoint:

--- a/src/phase_spaces/utility.jl
+++ b/src/phase_spaces/utility.jl
@@ -3,7 +3,9 @@
 
 # function assembling the correct type information for the tuple of ParticleStatefuls in a phasespace point constructed from momenta
 @inline function _assemble_tuple_type(
-    particle_types::Tuple{SPECIES_T,Vararg{QEDbase.AbstractParticleType}}, dir::DIR_T, ELTYPE::Type
+    particle_types::Tuple{SPECIES_T,Vararg{QEDbase.AbstractParticleType}},
+    dir::DIR_T,
+    ELTYPE::Type,
 ) where {SPECIES_T<:QEDbase.AbstractParticleType,DIR_T<:QEDbase.ParticleDirection}
     return (
         ParticleStateful{DIR_T,SPECIES_T,ELTYPE},

--- a/src/phase_spaces/utility.jl
+++ b/src/phase_spaces/utility.jl
@@ -1,10 +1,10 @@
 # recursion termination: base case
-@inline _assemble_tuple_type(::Tuple{}, ::ParticleDirection, ::Type) = ()
+@inline _assemble_tuple_type(::Tuple{}, ::QEDbase.ParticleDirection, ::Type) = ()
 
 # function assembling the correct type information for the tuple of ParticleStatefuls in a phasespace point constructed from momenta
 @inline function _assemble_tuple_type(
-    particle_types::Tuple{SPECIES_T,Vararg{AbstractParticleType}}, dir::DIR_T, ELTYPE::Type
-) where {SPECIES_T<:AbstractParticleType,DIR_T<:ParticleDirection}
+    particle_types::Tuple{SPECIES_T,Vararg{QEDbase.AbstractParticleType}}, dir::DIR_T, ELTYPE::Type
+) where {SPECIES_T<:QEDbase.AbstractParticleType,DIR_T<:QEDbase.ParticleDirection}
     return (
         ParticleStateful{DIR_T,SPECIES_T,ELTYPE},
         _assemble_tuple_type(particle_types[2:end], dir, ELTYPE)...,
@@ -12,13 +12,13 @@
 end
 
 # recursion termination: success
-@inline _recursive_type_check(::Tuple{}, ::Tuple{}, ::ParticleDirection) = nothing
+@inline _recursive_type_check(::Tuple{}, ::Tuple{}, ::QEDbase.ParticleDirection) = nothing
 
 # recursion termination: overload for unequal number of particles
 @inline function _recursive_type_check(
     ::Tuple{Vararg{ParticleStateful,N}},
-    ::Tuple{Vararg{AbstractParticleType,M}},
-    dir::ParticleDirection,
+    ::Tuple{Vararg{QEDbase.AbstractParticleType,M}},
+    dir::QEDbase.ParticleDirection,
 ) where {N,M}
     throw(InvalidInputError("expected $(M) $(dir) particles for the process but got $(N)"))
     return nothing
@@ -27,14 +27,14 @@ end
 # recursion termination: overload for invalid types
 @inline function _recursive_type_check(
     ::Tuple{ParticleStateful{DIR_IN_T,SPECIES_IN_T},Vararg{ParticleStateful,N}},
-    ::Tuple{SPECIES_T,Vararg{AbstractParticleType,N}},
+    ::Tuple{SPECIES_T,Vararg{QEDbase.AbstractParticleType,N}},
     dir::DIR_T,
 ) where {
     N,
-    DIR_IN_T<:ParticleDirection,
-    DIR_T<:ParticleDirection,
-    SPECIES_IN_T<:AbstractParticleType,
-    SPECIES_T<:AbstractParticleType,
+    DIR_IN_T<:QEDbase.ParticleDirection,
+    DIR_T<:QEDbase.ParticleDirection,
+    SPECIES_IN_T<:QEDbase.AbstractParticleType,
+    SPECIES_T<:QEDbase.AbstractParticleType,
 }
     throw(
         InvalidInputError(
@@ -46,22 +46,22 @@ end
 
 @inline function _recursive_type_check(
     t::Tuple{ParticleStateful{DIR_T,SPECIES_T},Vararg{ParticleStateful,N}},
-    p::Tuple{SPECIES_T,Vararg{AbstractParticleType,N}},
+    p::Tuple{SPECIES_T,Vararg{QEDbase.AbstractParticleType,N}},
     dir::DIR_T,
-) where {N,DIR_T<:ParticleDirection,SPECIES_T<:AbstractParticleType}
+) where {N,DIR_T<:QEDbase.ParticleDirection,SPECIES_T<:QEDbase.AbstractParticleType}
     return _recursive_type_check(t[2:end], p[2:end], dir)
 end
 
 @inline function _check_psp(
     in_proc::P_IN_Ts, out_proc::P_OUT_Ts, in_p::IN_Ts, out_p::OUT_Ts
 ) where {
-    P_IN_Ts<:Tuple{Vararg{AbstractParticleType}},
-    P_OUT_Ts<:Tuple{Vararg{AbstractParticleType}},
+    P_IN_Ts<:Tuple{Vararg{QEDbase.AbstractParticleType}},
+    P_OUT_Ts<:Tuple{Vararg{QEDbase.AbstractParticleType}},
     IN_Ts<:Tuple{Vararg{ParticleStateful}},
     OUT_Ts<:Tuple{},
 }
     # specific overload for InPhaseSpacePoint
-    _recursive_type_check(in_p, in_proc, Incoming())
+    _recursive_type_check(in_p, in_proc, QEDbase.Incoming())
 
     return typeof(in_p[1].mom)
 end
@@ -69,13 +69,13 @@ end
 @inline function _check_psp(
     in_proc::P_IN_Ts, out_proc::P_OUT_Ts, in_p::IN_Ts, out_p::OUT_Ts
 ) where {
-    P_IN_Ts<:Tuple{Vararg{AbstractParticleType}},
-    P_OUT_Ts<:Tuple{Vararg{AbstractParticleType}},
+    P_IN_Ts<:Tuple{Vararg{QEDbase.AbstractParticleType}},
+    P_OUT_Ts<:Tuple{Vararg{QEDbase.AbstractParticleType}},
     IN_Ts<:Tuple{},
     OUT_Ts<:Tuple{Vararg{ParticleStateful}},
 }
     # specific overload for OutPhaseSpacePoint
-    _recursive_type_check(out_p, out_proc, Outgoing())
+    _recursive_type_check(out_p, out_proc, QEDbase.Outgoing())
 
     return typeof(out_p[1].mom)
 end
@@ -83,16 +83,16 @@ end
 @inline function _check_psp(
     in_proc::P_IN_Ts, out_proc::P_OUT_Ts, in_p::IN_Ts, out_p::OUT_Ts
 ) where {
-    P_IN_Ts<:Tuple{Vararg{AbstractParticleType}},
-    P_OUT_Ts<:Tuple{Vararg{AbstractParticleType}},
+    P_IN_Ts<:Tuple{Vararg{QEDbase.AbstractParticleType}},
+    P_OUT_Ts<:Tuple{Vararg{QEDbase.AbstractParticleType}},
     IN_Ts<:Tuple{Vararg{ParticleStateful}},
     OUT_Ts<:Tuple{Vararg{ParticleStateful}},
 }
     # in_proc/out_proc contain only species types
     # in_p/out_p contain full ParticleStateful types
 
-    _recursive_type_check(in_p, in_proc, Incoming())
-    _recursive_type_check(out_p, out_proc, Outgoing())
+    _recursive_type_check(in_p, in_proc, QEDbase.Incoming())
+    _recursive_type_check(out_p, out_proc, QEDbase.Outgoing())
 
     return typeof(out_p[1].mom)
 end
@@ -104,7 +104,7 @@ end
 Returns the element type of the [`PhaseSpacePoint`](@ref) object or type, e.g. `SFourMomentum`.
 
 ```jldoctest
-julia> using QEDprocesses; using QEDbase;
+julia> using QEDprocesses; using QEDcore
 
 julia> psp = PhaseSpacePoint(Compton(), PerturbativeQED(), PhasespaceDefinition(SphericalCoordinateSystem(), ElectronRestFrame()), Tuple(rand(SFourMomentum) for _ in 1:2), Tuple(rand(SFourMomentum) for _ in 1:2));
 
@@ -125,7 +125,7 @@ end
 
 # convenience function building a type stable tuple of ParticleStatefuls from the given process, momenta, and direction
 function _build_particle_statefuls(
-    proc::AbstractProcessDefinition, moms::NTuple{N,ELEMENT}, dir::ParticleDirection
+    proc::AbstractProcessDefinition, moms::NTuple{N,ELEMENT}, dir::QEDbase.ParticleDirection
 ) where {N,ELEMENT<:QEDbase.AbstractFourMomentum}
     N == number_particles(proc, dir) || throw(
         InvalidInputError(

--- a/src/processes/one_photon_compton/perturbative/cross_section.jl
+++ b/src/processes/one_photon_compton/perturbative/cross_section.jl
@@ -27,16 +27,20 @@ end
 
 @inline function _all_onshell(psp::PhaseSpacePoint{<:Compton})
     return @inbounds isapprox(
-            QEDbase.getMass2(momentum(psp, QEDbase.Incoming(), 1)), QEDbase.mass(incoming_particles(psp.proc)[1])^2
+            QEDbase.getMass2(momentum(psp, QEDbase.Incoming(), 1)),
+            QEDbase.mass(incoming_particles(psp.proc)[1])^2,
         ) &&
         isapprox(
-            QEDbase.getMass2(momentum(psp, QEDbase.Incoming(), 2)), QEDbase.mass(incoming_particles(psp.proc)[2])^2
+            QEDbase.getMass2(momentum(psp, QEDbase.Incoming(), 2)),
+            QEDbase.mass(incoming_particles(psp.proc)[2])^2,
         ) &&
         isapprox(
-            QEDbase.getMass2(momentum(psp, QEDbase.Outgoing(), 1)), QEDbase.mass(outgoing_particles(psp.proc)[1])^2
+            QEDbase.getMass2(momentum(psp, QEDbase.Outgoing(), 1)),
+            QEDbase.mass(outgoing_particles(psp.proc)[1])^2,
         ) &&
         isapprox(
-            QEDbase.getMass2(momentum(psp, QEDbase.Outgoing(), 2)), QEDbase.mass(outgoing_particles(psp.proc)[2])^2
+            QEDbase.getMass2(momentum(psp, QEDbase.Outgoing(), 2)),
+            QEDbase.mass(outgoing_particles(psp.proc)[2])^2,
         )
 end
 
@@ -70,12 +74,20 @@ end
     out_electron_mom = out_ps[1]
     out_photon_mom = out_ps[2]
 
-    in_electron_state = base_state(QEDbase.Electron(), QEDbase.Incoming(), in_electron_mom, proc.in_spin)
-    in_photon_state = base_state(QEDbase.Photon(), QEDbase.Incoming(), in_photon_mom, proc.in_pol)
+    in_electron_state = base_state(
+        QEDbase.Electron(), QEDbase.Incoming(), in_electron_mom, proc.in_spin
+    )
+    in_photon_state = base_state(
+        QEDbase.Photon(), QEDbase.Incoming(), in_photon_mom, proc.in_pol
+    )
 
-    out_electron_state = base_state(QEDbase.Electron(), QEDbase.Outgoing(), out_electron_mom, proc.out_spin)
+    out_electron_state = base_state(
+        QEDbase.Electron(), QEDbase.Outgoing(), out_electron_mom, proc.out_spin
+    )
 
-    out_photon_state = base_state(QEDbase.Photon(), QEDbase.Outgoing(), out_photon_mom, proc.out_pol)
+    out_photon_state = base_state(
+        QEDbase.Photon(), QEDbase.Outgoing(), out_photon_mom, proc.out_pol
+    )
     return _pert_compton_matrix_element(
         in_electron_mom,
         in_electron_state,

--- a/src/processes/one_photon_compton/perturbative/cross_section.jl
+++ b/src/processes/one_photon_compton/perturbative/cross_section.jl
@@ -4,12 +4,12 @@
 #####
 
 function _incident_flux(in_psp::InPhaseSpacePoint{<:Compton,<:PerturbativeQED})
-    return momentum(in_psp, Incoming(), 1) * momentum(in_psp, Incoming(), 2)
+    return momentum(in_psp, QEDbase.Incoming(), 1) * momentum(in_psp, QEDbase.Incoming(), 2)
 end
 
 function _matrix_element(psp::PhaseSpacePoint{<:Compton,PerturbativeQED})
-    in_ps = momenta(psp, Incoming())
-    out_ps = momenta(psp, Outgoing())
+    in_ps = momenta(psp, QEDbase.Incoming())
+    out_ps = momenta(psp, QEDbase.Outgoing())
     return _pert_compton_matrix_element(psp.proc, in_ps, out_ps)
 end
 
@@ -27,24 +27,24 @@ end
 
 @inline function _all_onshell(psp::PhaseSpacePoint{<:Compton})
     return @inbounds isapprox(
-            getMass2(momentum(psp, Incoming(), 1)), mass(incoming_particles(psp.proc)[1])^2
+            QEDbase.getMass2(momentum(psp, QEDbase.Incoming(), 1)), QEDbase.mass(incoming_particles(psp.proc)[1])^2
         ) &&
         isapprox(
-            getMass2(momentum(psp, Incoming(), 2)), mass(incoming_particles(psp.proc)[2])^2
+            QEDbase.getMass2(momentum(psp, QEDbase.Incoming(), 2)), QEDbase.mass(incoming_particles(psp.proc)[2])^2
         ) &&
         isapprox(
-            getMass2(momentum(psp, Outgoing(), 1)), mass(outgoing_particles(psp.proc)[1])^2
+            QEDbase.getMass2(momentum(psp, QEDbase.Outgoing(), 1)), QEDbase.mass(outgoing_particles(psp.proc)[1])^2
         ) &&
         isapprox(
-            getMass2(momentum(psp, Outgoing(), 2)), mass(outgoing_particles(psp.proc)[2])^2
+            QEDbase.getMass2(momentum(psp, QEDbase.Outgoing(), 2)), QEDbase.mass(outgoing_particles(psp.proc)[2])^2
         )
 end
 
 @inline function _is_in_phasespace(psp::PhaseSpacePoint{<:Compton,<:PerturbativeQED})
     @inbounds if (
         !isapprox(
-            momentum(psp, Incoming(), 1) + momentum(psp, Incoming(), 2),
-            momentum(psp, Outgoing(), 1) + momentum(psp, Outgoing(), 2),
+            momentum(psp, QEDbase.Incoming(), 1) + momentum(psp, QEDbase.Incoming(), 2),
+            momentum(psp, QEDbase.Outgoing(), 1) + momentum(psp, QEDbase.Outgoing(), 2),
         )
     )
         return false
@@ -53,8 +53,8 @@ end
 end
 
 @inline function _phase_space_factor(psp::PhaseSpacePoint{<:Compton,PerturbativeQED})
-    in_ps = momenta(psp, Incoming())
-    out_ps = momenta(psp, Outgoing())
+    in_ps = momenta(psp, QEDbase.Incoming())
+    out_ps = momenta(psp, QEDbase.Outgoing())
     return _pert_compton_ps_fac(psp.ps_def, in_ps[2], out_ps[2])
 end
 
@@ -70,12 +70,12 @@ end
     out_electron_mom = out_ps[1]
     out_photon_mom = out_ps[2]
 
-    in_electron_state = base_state(Electron(), Incoming(), in_electron_mom, proc.in_spin)
-    in_photon_state = base_state(Photon(), Incoming(), in_photon_mom, proc.in_pol)
+    in_electron_state = base_state(QEDbase.Electron(), QEDbase.Incoming(), in_electron_mom, proc.in_spin)
+    in_photon_state = base_state(QEDbase.Photon(), QEDbase.Incoming(), in_photon_mom, proc.in_pol)
 
-    out_electron_state = base_state(Electron(), Outgoing(), out_electron_mom, proc.out_spin)
+    out_electron_state = base_state(QEDbase.Electron(), QEDbase.Outgoing(), out_electron_mom, proc.out_spin)
 
-    out_photon_state = base_state(Photon(), Outgoing(), out_photon_mom, proc.out_pol)
+    out_photon_state = base_state(QEDbase.Photon(), QEDbase.Outgoing(), out_photon_mom, proc.out_pol)
     return _pert_compton_matrix_element(
         in_electron_mom,
         in_electron_state,
@@ -139,8 +139,8 @@ function _pert_compton_matrix_element_single(
     in_ph_slashed = slashed(in_photon_state)
     out_ph_slashed = slashed(out_photon_state)
 
-    prop1 = _fermion_propagator(in_photon_mom + in_electron_mom, mass(Electron()))
-    prop2 = _fermion_propagator(in_electron_mom - out_photon_mom, mass(Electron()))
+    prop1 = _fermion_propagator(in_photon_mom + in_electron_mom, mass(QEDbase.Electron()))
+    prop2 = _fermion_propagator(in_electron_mom - out_photon_mom, mass(QEDbase.Electron()))
 
     # TODO: fermion propagator is not yet in QEDbase
     diagram_1 =
@@ -165,7 +165,7 @@ function _pert_compton_ps_fac(
     in_ps_def::PhasespaceDefinition{inCS,ElectronRestFrame}, in_photon_mom, out_photon_mom
 ) where {inCS}
     # TODO
-    omega = getE(in_photon_mom)
-    omega_prime = getE(out_photon_mom)
-    return omega_prime^2 / (16 * pi^2 * omega * mass(Electron()))
+    omega = QEDbase.getE(in_photon_mom)
+    omega_prime = QEDbase.getE(out_photon_mom)
+    return omega_prime^2 / (16 * pi^2 * omega * mass(QEDbase.Electron()))
 end

--- a/src/processes/one_photon_compton/perturbative/total_probability.jl
+++ b/src/processes/one_photon_compton/perturbative/total_probability.jl
@@ -1,6 +1,6 @@
 
 function _total_probability(in_psp::InPhaseSpacePoint{<:Compton,<:PerturbativeQED})
-    omega = getE(momentum(in_psp[Incoming(), 2]))
+    omega = QEDbase.getE(momentum(in_psp[QEDbase.Incoming(), 2]))
 
     function func(x)
         return unsafe_differential_probability(

--- a/src/processes/one_photon_compton/process.jl
+++ b/src/processes/one_photon_compton/process.jl
@@ -8,10 +8,10 @@
 """
 struct Compton{InElectronSpin,InPhotonPol,OutElectronSpin,OutPhotonPol} <:
        AbstractProcessDefinition where {
-    InElectronSpin<:AbstractSpin,
-    InPhotonPol<:AbstractPolarization,
-    OutElectronSpin<:AbstractSpin,
-    OutPhotonPol<:AbstractPolarization,
+    InElectronSpin<:QEDbase.AbstractSpin,
+    InPhotonPol<:QEDbase.AbstractPolarization,
+    OutElectronSpin<:QEDbase.AbstractSpin,
+    OutPhotonPol<:QEDbase.AbstractPolarization,
 }
     in_spin::InElectronSpin
     in_pol::InPhotonPol
@@ -21,12 +21,12 @@ struct Compton{InElectronSpin,InPhotonPol,OutElectronSpin,OutPhotonPol} <:
 end
 
 function Compton()
-    return Compton(AllSpin(), AllPol(), AllSpin(), AllPol())
+    return Compton(QEDbase.AllSpin(), QEDbase.AllPol(), QEDbase.AllSpin(), QEDbase.AllPol())
 end
 
-Compton(in_pol::AbstractPolarization) = Compton(AllSpin(), in_pol, AllSpin(), AllPol())
-function Compton(in_pol::AbstractPolarization, out_pol::AbstractPolarization)
-    return Compton(AllSpin(), in_pol, AllSpin(), out_pol)
+Compton(in_pol::QEDbase.AbstractPolarization) = Compton(QEDbase.AllSpin(), in_pol, QEDbase.AllSpin(), QEDbase.AllPol())
+function Compton(in_pol::QEDbase.AbstractPolarization, out_pol::QEDbase.AbstractPolarization)
+    return Compton(QEDbase.AllSpin(), in_pol, QEDbase.AllSpin(), out_pol)
 end
 
 _polarizations(proc::Compton) = (proc.in_pol, proc.out_pol)
@@ -35,26 +35,26 @@ _in_spin_and_pol(proc::Compton) = (proc.in_spin, proc.in_pol)
 _out_spin_and_pol(proc::Compton) = (proc.out_spin, proc.out_pol)
 
 function QEDprocesses.incoming_particles(::Compton)
-    return (Electron(), Photon())
+    return (QEDbase.Electron(), QEDbase.Photon())
 end
 
 function QEDprocesses.outgoing_particles(::Compton)
-    return (Electron(), Photon())
+    return (QEDbase.Electron(), QEDbase.Photon())
 end
 
-function _spin_or_pol(process::Compton, ::Electron, ::Incoming)
+function _spin_or_pol(process::Compton, ::QEDbase.Electron, ::QEDbase.Incoming)
     return process.in_spin
 end
 
-function _spin_or_pol(process::Compton, ::Electron, ::Outgoing)
+function _spin_or_pol(process::Compton, ::QEDbase.Electron, ::QEDbase.Outgoing)
     return process.out_spin
 end
 
-function _spin_or_pol(process::Compton, ::Photon, ::Incoming)
+function _spin_or_pol(process::Compton, ::QEDbase.Photon, ::QEDbase.Incoming)
     return process.in_pol
 end
 
-function _spin_or_pol(process::Compton, ::Photon, ::Outgoing)
+function _spin_or_pol(process::Compton, ::QEDbase.Photon, ::QEDbase.Outgoing)
     return process.out_pol
 end
 

--- a/src/processes/one_photon_compton/process.jl
+++ b/src/processes/one_photon_compton/process.jl
@@ -24,8 +24,12 @@ function Compton()
     return Compton(QEDbase.AllSpin(), QEDbase.AllPol(), QEDbase.AllSpin(), QEDbase.AllPol())
 end
 
-Compton(in_pol::QEDbase.AbstractPolarization) = Compton(QEDbase.AllSpin(), in_pol, QEDbase.AllSpin(), QEDbase.AllPol())
-function Compton(in_pol::QEDbase.AbstractPolarization, out_pol::QEDbase.AbstractPolarization)
+function Compton(in_pol::QEDbase.AbstractPolarization)
+    return Compton(QEDbase.AllSpin(), in_pol, QEDbase.AllSpin(), QEDbase.AllPol())
+end
+function Compton(
+    in_pol::QEDbase.AbstractPolarization, out_pol::QEDbase.AbstractPolarization
+)
     return Compton(QEDbase.AllSpin(), in_pol, QEDbase.AllSpin(), out_pol)
 end
 

--- a/src/propagators.jl
+++ b/src/propagators.jl
@@ -38,7 +38,7 @@ function _scalar_propagator(K::QEDbase.AbstractFourMomentum, mass::Real)
 end
 
 function _scalar_propagator(K::QEDbase.AbstractFourMomentum)
-    return one(getT(K)) / (K * K)
+    return one(QEDbase.getT(K)) / (K * K)
 end
 
 function _fermion_propagator(P::QEDbase.AbstractFourMomentum, mass::Real)
@@ -49,14 +49,14 @@ function _fermion_propagator(P::QEDbase.AbstractFourMomentum)
     return (slashed(P)) * _scalar_propagator(P)
 end
 
-function propagator(particle_type::BosonLike, K::QEDbase.AbstractFourMomentum)
+function propagator(particle_type::QEDbase.BosonLike, K::QEDbase.AbstractFourMomentum)
     return _scalar_propagator(K, mass(particle_type))
 end
 
-function propagator(particle_type::Photon, K::QEDbase.AbstractFourMomentum)
+function propagator(particle_type::QEDbase.Photon, K::QEDbase.AbstractFourMomentum)
     return _scalar_propagator(K)
 end
 
-function propagator(particle_type::FermionLike, P::QEDbase.AbstractFourMomentum)
+function propagator(particle_type::QEDbase.FermionLike, P::QEDbase.AbstractFourMomentum)
     return _fermion_propagator(P, mass(particle_type))
 end

--- a/src/restruct_patch.jl
+++ b/src/restruct_patch.jl
@@ -1,0 +1,30 @@
+
+# function barrier for base_state
+#
+# WARN: This file can be removed if the implementations of `base_state` are removed from
+# `QEDbase`.
+#
+# TL;DR: 
+# The final state of the restructuing is, that QEDbase exports the symbol `base_state` and 
+# QEDcore implements the concrete functions. However, currently, QEDbase provides both,
+# the symbol and the implementation. Hiding this implementation in the QEDbase namespace 
+# causes the usage of QEDbase.base_state implementation and not the QEDcore.base_state. 
+# This is problematic, because the return type of `base_state` must be from `QEDcore`,
+# which is not the case for `QEDbase.base_state`. Therefore, we need to recast the returns
+# of `QEDbase.base_state` into types from `QEDcore`.
+#
+# This should not break if we update QEDbase by removing the concrete implementation of
+# `base_state` in `QEDbase`, because `QEDcore` adds the implementations to the symbol 
+# `QEDbase.base_state` anyway. 
+
+base_state(p::QEDbase.Fermion,d::QEDbase.Incoming,mom,spin) = BiSpinor(QEDbase.base_state(p,d,mom,spin))
+base_state(p::QEDbase.AntiFermion,d::QEDbase.Incoming,mom,spin) = AdjointBiSpinor(QEDbase.base_state(p,d,mom,spin))
+base_state(p::QEDbase.Fermion,d::QEDbase.Outgoing,mom,spin) = AdjointBiSpinor(QEDbase.base_state(p,d,mom,spin))
+base_state(p::QEDbase.AntiFermion,d::QEDbase.Outgoing,mom,spin) = BiSpinor(QEDbase.base_state(p,d,mom,spin))
+base_state(p::QEDbase.BosonLike,d::QEDbase.ParticleDirection,mom,spin) = SLorentzVector(QEDbase.base_state(p,d,mom,spin))
+
+base_state(p::QEDbase.Fermion,d::QEDbase.Incoming,mom,spin::QEDbase.AllSpin) = BiSpinor.(QEDbase.base_state(p,d,mom,spin))
+base_state(p::QEDbase.AntiFermion,d::QEDbase.Incoming,mom,spin::QEDbase.AllSpin) = AdjointBiSpinor.(QEDbase.base_state(p,d,mom,spin))
+base_state(p::QEDbase.Fermion,d::QEDbase.Outgoing,mom,spin::QEDbase.AllSpin) = AdjointBiSpinor.(QEDbase.base_state(p,d,mom,spin))
+base_state(p::QEDbase.AntiFermion,d::QEDbase.Outgoing,mom,spin::QEDbase.AllSpin) = BiSpinor.(QEDbase.base_state(p,d,mom,spin))
+base_state(p::QEDbase.BosonLike,d::QEDbase.ParticleDirection,mom,spin::QEDbase.AllPol) = SLorentzVector.(QEDbase.base_state(p,d,mom,spin))

--- a/src/restruct_patch.jl
+++ b/src/restruct_patch.jl
@@ -17,14 +17,36 @@
 # `base_state` in `QEDbase`, because `QEDcore` adds the implementations to the symbol 
 # `QEDbase.base_state` anyway. 
 
-base_state(p::QEDbase.Fermion,d::QEDbase.Incoming,mom,spin) = BiSpinor(QEDbase.base_state(p,d,mom,spin))
-base_state(p::QEDbase.AntiFermion,d::QEDbase.Incoming,mom,spin) = AdjointBiSpinor(QEDbase.base_state(p,d,mom,spin))
-base_state(p::QEDbase.Fermion,d::QEDbase.Outgoing,mom,spin) = AdjointBiSpinor(QEDbase.base_state(p,d,mom,spin))
-base_state(p::QEDbase.AntiFermion,d::QEDbase.Outgoing,mom,spin) = BiSpinor(QEDbase.base_state(p,d,mom,spin))
-base_state(p::QEDbase.BosonLike,d::QEDbase.ParticleDirection,mom,spin) = SLorentzVector(QEDbase.base_state(p,d,mom,spin))
+function base_state(p::QEDbase.Fermion, d::QEDbase.Incoming, mom, spin)
+    return BiSpinor(QEDbase.base_state(p, d, mom, spin))
+end
+function base_state(p::QEDbase.AntiFermion, d::QEDbase.Incoming, mom, spin)
+    return AdjointBiSpinor(QEDbase.base_state(p, d, mom, spin))
+end
+function base_state(p::QEDbase.Fermion, d::QEDbase.Outgoing, mom, spin)
+    return AdjointBiSpinor(QEDbase.base_state(p, d, mom, spin))
+end
+function base_state(p::QEDbase.AntiFermion, d::QEDbase.Outgoing, mom, spin)
+    return BiSpinor(QEDbase.base_state(p, d, mom, spin))
+end
+function base_state(p::QEDbase.BosonLike, d::QEDbase.ParticleDirection, mom, spin)
+    return SLorentzVector(QEDbase.base_state(p, d, mom, spin))
+end
 
-base_state(p::QEDbase.Fermion,d::QEDbase.Incoming,mom,spin::QEDbase.AllSpin) = BiSpinor.(QEDbase.base_state(p,d,mom,spin))
-base_state(p::QEDbase.AntiFermion,d::QEDbase.Incoming,mom,spin::QEDbase.AllSpin) = AdjointBiSpinor.(QEDbase.base_state(p,d,mom,spin))
-base_state(p::QEDbase.Fermion,d::QEDbase.Outgoing,mom,spin::QEDbase.AllSpin) = AdjointBiSpinor.(QEDbase.base_state(p,d,mom,spin))
-base_state(p::QEDbase.AntiFermion,d::QEDbase.Outgoing,mom,spin::QEDbase.AllSpin) = BiSpinor.(QEDbase.base_state(p,d,mom,spin))
-base_state(p::QEDbase.BosonLike,d::QEDbase.ParticleDirection,mom,spin::QEDbase.AllPol) = SLorentzVector.(QEDbase.base_state(p,d,mom,spin))
+function base_state(p::QEDbase.Fermion, d::QEDbase.Incoming, mom, spin::QEDbase.AllSpin)
+    return BiSpinor.(QEDbase.base_state(p, d, mom, spin))
+end
+function base_state(p::QEDbase.AntiFermion, d::QEDbase.Incoming, mom, spin::QEDbase.AllSpin)
+    return AdjointBiSpinor.(QEDbase.base_state(p, d, mom, spin))
+end
+function base_state(p::QEDbase.Fermion, d::QEDbase.Outgoing, mom, spin::QEDbase.AllSpin)
+    return AdjointBiSpinor.(QEDbase.base_state(p, d, mom, spin))
+end
+function base_state(p::QEDbase.AntiFermion, d::QEDbase.Outgoing, mom, spin::QEDbase.AllSpin)
+    return BiSpinor.(QEDbase.base_state(p, d, mom, spin))
+end
+function base_state(
+    p::QEDbase.BosonLike, d::QEDbase.ParticleDirection, mom, spin::QEDbase.AllPol
+)
+    return SLorentzVector.(QEDbase.base_state(p, d, mom, spin))
+end

--- a/test/interfaces/process_interface.jl
+++ b/test/interfaces/process_interface.jl
@@ -1,5 +1,5 @@
 using Random
-import QEDbase
+using QEDbase: QEDbase
 using QEDcore
 using QEDprocesses
 

--- a/test/interfaces/process_interface.jl
+++ b/test/interfaces/process_interface.jl
@@ -1,5 +1,6 @@
 using Random
-using QEDbase
+import QEDbase
+using QEDcore
 using QEDprocesses
 
 RNG = MersenneTwister(137137)

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -1,6 +1,7 @@
 using Random
 using StaticArrays
-using QEDbase
+import QEDbase
+using QEDcore
 using QEDprocesses
 
 # can be removed when QEDbase exports them
@@ -19,8 +20,8 @@ BUF = IOBuffer()
 end
 
 @testset "Stateful Particle" begin
-    DIRECTIONS = [Incoming(), Outgoing()]
-    SPECIES = [Electron(), Positron()] #=, Muon(), AntiMuon(), Tauon(), AntiTauon()=#
+    DIRECTIONS = [QEDbase.Incoming(), QEDbase.Outgoing()]
+    SPECIES = [QEDbase.Electron(), QEDbase.Positron()] #=, Muon(), AntiMuon(), Tauon(), AntiTauon()=#
 
     for (species, dir) in Iterators.product(SPECIES, DIRECTIONS)
         mom = rand(RNG, SFourMomentum)
@@ -28,14 +29,14 @@ end
         particle_stateful = ParticleStateful(dir, species, mom)
 
         # particle interface
-        @test is_fermion(particle_stateful) == is_fermion(species)
-        @test is_boson(particle_stateful) == is_boson(species)
-        @test is_particle(particle_stateful) == is_particle(species)
-        @test is_anti_particle(particle_stateful) == is_anti_particle(species)
-        @test is_incoming(particle_stateful) == is_incoming(dir)
-        @test is_outgoing(particle_stateful) == is_outgoing(dir)
-        @test mass(particle_stateful) == mass(species)
-        @test charge(particle_stateful) == charge(species)
+        @test QEDbase.is_fermion(particle_stateful) == QEDbase.is_fermion(species)
+        @test QEDbase.is_boson(particle_stateful) == QEDbase.is_boson(species)
+        @test QEDbase.is_particle(particle_stateful) == QEDbase.is_particle(species)
+        @test QEDbase.is_anti_particle(particle_stateful) == QEDbase.is_anti_particle(species)
+        @test QEDbase.is_incoming(particle_stateful) == QEDbase.is_incoming(dir)
+        @test QEDbase.is_outgoing(particle_stateful) == QEDbase.is_outgoing(dir)
+        @test QEDbase.mass(particle_stateful) == QEDbase.mass(species)
+        @test QEDbase.charge(particle_stateful) == QEDbase.charge(species)
 
         # accessors
         @test particle_stateful.dir == dir
@@ -61,10 +62,10 @@ end
     out_el_mom = rand(RNG, SFourMomentum)
     out_ph_mom = rand(RNG, SFourMomentum)
 
-    in_el = ParticleStateful(Incoming(), Electron(), in_el_mom)
-    in_ph = ParticleStateful(Incoming(), Photon(), in_ph_mom)
-    out_el = ParticleStateful(Outgoing(), Electron(), out_el_mom)
-    out_ph = ParticleStateful(Outgoing(), Photon(), out_ph_mom)
+    in_el = ParticleStateful(QEDbase.Incoming(), QEDbase.Electron(), in_el_mom)
+    in_ph = ParticleStateful(QEDbase.Incoming(), QEDbase.Photon(), in_ph_mom)
+    out_el = ParticleStateful(QEDbase.Outgoing(), QEDbase.Electron(), out_el_mom)
+    out_ph = ParticleStateful(QEDbase.Outgoing(), QEDbase.Photon(), out_ph_mom)
 
     in_particles_valid = (in_el, in_ph)
     in_particles_invalid = (in_el, out_ph)
@@ -73,7 +74,7 @@ end
     out_particles_invalid = (out_el, in_ph)
 
     model = TESTMODEL
-    process = TestImplementation.TestProcess((Electron(), Photon()), (Electron(), Photon()))
+    process = TestImplementation.TestProcess((QEDbase.Electron(), QEDbase.Photon()), (QEDbase.Electron(), QEDbase.Photon()))
     phasespace_def = TESTPSDEF
 
     psp = PhaseSpacePoint(
@@ -91,15 +92,15 @@ end
     ) isa RegexMatch
 
     @testset "Accessor" begin
-        @test momentum(psp, Incoming(), 1) == in_el.mom
-        @test momentum(psp, Incoming(), 2) == in_ph.mom
-        @test momentum(psp, Outgoing(), 1) == out_el.mom
-        @test momentum(psp, Outgoing(), 2) == out_ph.mom
+        @test momentum(psp, QEDbase.Incoming(), 1) == in_el.mom
+        @test momentum(psp, QEDbase.Incoming(), 2) == in_ph.mom
+        @test momentum(psp, QEDbase.Outgoing(), 1) == out_el.mom
+        @test momentum(psp, QEDbase.Outgoing(), 2) == out_ph.mom
 
-        @test psp[Incoming(), 1] == in_el
-        @test psp[Incoming(), 2] == in_ph
-        @test psp[Outgoing(), 1] == out_el
-        @test psp[Outgoing(), 2] == out_ph
+        @test psp[QEDbase.Incoming(), 1] == in_el
+        @test psp[QEDbase.Incoming(), 2] == in_ph
+        @test psp[QEDbase.Outgoing(), 1] == out_el
+        @test psp[QEDbase.Outgoing(), 2] == out_ph
     end
 
     @testset "Error handling" begin
@@ -138,15 +139,15 @@ end
             )
         end
 
-        @test_throws BoundsError momentum(psp, Incoming(), -1)
-        @test_throws BoundsError momentum(psp, Outgoing(), -1)
-        @test_throws BoundsError momentum(psp, Incoming(), 4)
-        @test_throws BoundsError momentum(psp, Outgoing(), 4)
+        @test_throws BoundsError momentum(psp, QEDbase.Incoming(), -1)
+        @test_throws BoundsError momentum(psp, QEDbase.Outgoing(), -1)
+        @test_throws BoundsError momentum(psp, QEDbase.Incoming(), 4)
+        @test_throws BoundsError momentum(psp, QEDbase.Outgoing(), 4)
 
-        @test_throws BoundsError psp[Incoming(), -1]
-        @test_throws BoundsError psp[Outgoing(), -1]
-        @test_throws BoundsError psp[Incoming(), 4]
-        @test_throws BoundsError psp[Outgoing(), 4]
+        @test_throws BoundsError psp[QEDbase.Incoming(), -1]
+        @test_throws BoundsError psp[QEDbase.Outgoing(), -1]
+        @test_throws BoundsError psp[QEDbase.Incoming(), 4]
+        @test_throws BoundsError psp[QEDbase.Outgoing(), 4]
 
         @test_throws InvalidInputError PhaseSpacePoint(
             process, model, phasespace_def, in_particles_invalid, out_particles_valid
@@ -174,10 +175,10 @@ end
         @test test_psp.model == model
         @test test_psp.ps_def == phasespace_def
 
-        @test test_psp[Incoming(), 1] == in_el
-        @test test_psp[Incoming(), 2] == in_ph
-        @test test_psp[Outgoing(), 1] == out_el
-        @test test_psp[Outgoing(), 2] == out_ph
+        @test test_psp[QEDbase.Incoming(), 1] == in_el
+        @test test_psp[QEDbase.Incoming(), 2] == in_ph
+        @test test_psp[QEDbase.Outgoing(), 1] == out_el
+        @test test_psp[QEDbase.Outgoing(), 2] == out_ph
     end
 
     @testset "Error handling from momenta" for (i, o) in

--- a/test/phase_spaces.jl
+++ b/test/phase_spaces.jl
@@ -1,6 +1,6 @@
 using Random
 using StaticArrays
-import QEDbase
+using QEDbase: QEDbase
 using QEDcore
 using QEDprocesses
 
@@ -32,7 +32,8 @@ end
         @test QEDbase.is_fermion(particle_stateful) == QEDbase.is_fermion(species)
         @test QEDbase.is_boson(particle_stateful) == QEDbase.is_boson(species)
         @test QEDbase.is_particle(particle_stateful) == QEDbase.is_particle(species)
-        @test QEDbase.is_anti_particle(particle_stateful) == QEDbase.is_anti_particle(species)
+        @test QEDbase.is_anti_particle(particle_stateful) ==
+            QEDbase.is_anti_particle(species)
         @test QEDbase.is_incoming(particle_stateful) == QEDbase.is_incoming(dir)
         @test QEDbase.is_outgoing(particle_stateful) == QEDbase.is_outgoing(dir)
         @test QEDbase.mass(particle_stateful) == QEDbase.mass(species)
@@ -74,7 +75,9 @@ end
     out_particles_invalid = (out_el, in_ph)
 
     model = TESTMODEL
-    process = TestImplementation.TestProcess((QEDbase.Electron(), QEDbase.Photon()), (QEDbase.Electron(), QEDbase.Photon()))
+    process = TestImplementation.TestProcess(
+        (QEDbase.Electron(), QEDbase.Photon()), (QEDbase.Electron(), QEDbase.Photon())
+    )
     phasespace_def = TESTPSDEF
 
     psp = PhaseSpacePoint(

--- a/test/processes/one_photon_compton/perturbative.jl
+++ b/test/processes/one_photon_compton/perturbative.jl
@@ -1,5 +1,6 @@
 
-using QEDbase
+import QEDbase
+using QEDcore
 using QEDprocesses
 using Random
 using StaticArrays
@@ -37,10 +38,10 @@ end
             IN_PS, OUT_PS = QEDprocesses._generate_momenta(
                 PROC, MODEL, PS_DEF, IN_COORDS, OUT_COORDS
             )
-            in_mom_square = getMass2.(IN_PS)
-            out_mom_square = getMass2.(OUT_PS)
-            in_masses = mass.(incoming_particles(PROC)) .^ 2
-            out_masses = mass.(outgoing_particles(PROC)) .^ 2
+            in_mom_square = QEDbase.getMass2.(IN_PS)
+            out_mom_square = QEDbase.getMass2.(OUT_PS)
+            in_masses = QEDbase.mass.(incoming_particles(PROC)) .^ 2
+            out_masses = QEDbase.mass.(outgoing_particles(PROC)) .^ 2
 
             # we need a larger ATOL than eps() here because the error is accumulated over several additions
             @test all(isapprox.(in_mom_square, in_masses, atol=4 * ATOL, rtol=RTOL))
@@ -75,7 +76,7 @@ end
             end
 
             @testset "x-pol and spin summed" begin
-                PROC = Compton(PolX())
+                PROC = Compton(QEDbase.PolX())
 
                 @testset "$cos_theta $phi" for (cos_theta, phi) in
                                                Iterators.product(COS_THETAS, PHIS)
@@ -97,7 +98,7 @@ end
             end
 
             @testset "y-pol and spin summed" begin
-                PROC = Compton(PolY())
+                PROC = Compton(QEDbase.PolY())
 
                 @testset "$cos_theta $phi" for (cos_theta, phi) in
                                                Iterators.product(COS_THETAS, PHIS)
@@ -154,7 +155,7 @@ end
 
                     out_moms = momenta(
                         PhaseSpacePoint(PROC, MODEL, PS_DEF, IN_COORDS, OUT_COORDS),
-                        Outgoing(),
+                        QEDbase.Outgoing(),
                     )
                     @test_throws MethodError total_cross_section(
                         OutPhaseSpacePoint(PROC, MODEL, PS_DEF, out_moms)

--- a/test/processes/one_photon_compton/perturbative.jl
+++ b/test/processes/one_photon_compton/perturbative.jl
@@ -1,5 +1,5 @@
 
-import QEDbase
+using QEDbase: QEDbase
 using QEDcore
 using QEDprocesses
 using Random

--- a/test/processes/one_photon_compton/process.jl
+++ b/test/processes/one_photon_compton/process.jl
@@ -1,9 +1,10 @@
 using QEDprocesses
 using Random
-using QEDbase
+import QEDbase
+using QEDcore
 
-POLS = [PolX(), PolY(), AllPol()]
-SPINS = [SpinUp(), SpinDown(), AllSpin()]
+POLS = [QEDbase.PolX(), QEDbase.PolY(), QEDbase.AllPol()]
+SPINS = [QEDbase.SpinUp(), QEDbase.SpinDown(), QEDbase.AllSpin()]
 POL_AND_SPIN_COMBINATIONS = Iterators.product(SPINS, POLS, SPINS, POLS)
 POL_COMBINATIONS = Iterators.product(POLS, POLS)
 BUF = IOBuffer()
@@ -11,50 +12,50 @@ BUF = IOBuffer()
 @testset "constructor" begin
     @testset "default" begin
         proc = Compton()
-        @test QEDprocesses._spin_or_pol(proc, Photon(), Incoming()) == AllPol()
-        @test QEDprocesses._spin_or_pol(proc, Electron(), Incoming()) == AllSpin()
-        @test QEDprocesses._spin_or_pol(proc, Photon(), Outgoing()) == AllPol()
-        @test QEDprocesses._spin_or_pol(proc, Electron(), Outgoing()) == AllSpin()
+        @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) == QEDbase.AllPol()
+        @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) == QEDbase.AllSpin()
+        @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) == QEDbase.AllPol()
+        @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) == QEDbase.AllSpin()
 
         print(BUF, proc)
         @test String(take!(BUF)) == "one-photon Compton scattering"
 
         show(BUF, MIME"text/plain"(), proc)
         @test String(take!(BUF)) ==
-            "one-photon Compton scattering\n    incoming: electron ($(AllSpin())), photon ($(AllPol()))\n    outgoing: electron ($(AllSpin())), photon ($(AllPol()))\n"
+            "one-photon Compton scattering\n    incoming: electron ($(QEDbase.AllSpin())), photon ($(QEDbase.AllPol()))\n    outgoing: electron ($(QEDbase.AllSpin())), photon ($(QEDbase.AllPol()))\n"
     end
 
     @testset "in_pol" begin
         @testset "$pol" for pol in POLS
             proc = Compton(pol)
-            @test QEDprocesses._spin_or_pol(proc, Electron(), Incoming()) == AllSpin()
-            @test QEDprocesses._spin_or_pol(proc, Photon(), Incoming()) == pol
-            @test QEDprocesses._spin_or_pol(proc, Electron(), Outgoing()) == AllSpin()
-            @test QEDprocesses._spin_or_pol(proc, Photon(), Outgoing()) == AllPol()
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) == QEDbase.AllSpin()
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) == pol
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) == QEDbase.AllSpin()
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) == QEDbase.AllPol()
 
             print(BUF, proc)
             @test String(take!(BUF)) == "one-photon Compton scattering"
 
             show(BUF, MIME"text/plain"(), proc)
             @test String(take!(BUF)) ==
-                "one-photon Compton scattering\n    incoming: electron ($(AllSpin())), photon ($(pol))\n    outgoing: electron ($(AllSpin())), photon ($(AllPol()))\n"
+                "one-photon Compton scattering\n    incoming: electron ($(QEDbase.AllSpin())), photon ($(pol))\n    outgoing: electron ($(QEDbase.AllSpin())), photon ($(QEDbase.AllPol()))\n"
         end
     end
 
     @testset "in_pol+out_pol" begin
         @testset "$in_pol, $out_pol" for (in_pol, out_pol) in POL_COMBINATIONS
             proc = Compton(in_pol, out_pol)
-            @test QEDprocesses._spin_or_pol(proc, Electron(), Incoming()) == AllSpin()
-            @test QEDprocesses._spin_or_pol(proc, Photon(), Incoming()) == in_pol
-            @test QEDprocesses._spin_or_pol(proc, Electron(), Outgoing()) == AllSpin()
-            @test QEDprocesses._spin_or_pol(proc, Photon(), Outgoing()) == out_pol
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) == QEDbase.AllSpin()
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) == in_pol
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) == QEDbase.AllSpin()
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) == out_pol
 
             print(BUF, proc)
             @test String(take!(BUF)) == "one-photon Compton scattering"
 
             show(BUF, MIME"text/plain"(), proc)
             @test String(take!(BUF)) ==
-                "one-photon Compton scattering\n    incoming: electron ($(AllSpin())), photon ($(in_pol))\n    outgoing: electron ($(AllSpin())), photon ($(out_pol))\n"
+                "one-photon Compton scattering\n    incoming: electron ($(QEDbase.AllSpin())), photon ($(in_pol))\n    outgoing: electron ($(QEDbase.AllSpin())), photon ($(out_pol))\n"
         end
     end
     @testset "all spins+pols" begin
@@ -62,10 +63,10 @@ BUF = IOBuffer()
             in_spin, in_pol, out_spin, out_pol
         ) in POL_AND_SPIN_COMBINATIONS
             proc = Compton(in_spin, in_pol, out_spin, out_pol)
-            @test QEDprocesses._spin_or_pol(proc, Electron(), Incoming()) == in_spin
-            @test QEDprocesses._spin_or_pol(proc, Photon(), Incoming()) == in_pol
-            @test QEDprocesses._spin_or_pol(proc, Electron(), Outgoing()) == out_spin
-            @test QEDprocesses._spin_or_pol(proc, Photon(), Outgoing()) == out_pol
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) == in_spin
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) == in_pol
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) == out_spin
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) == out_pol
 
             print(BUF, proc)
             @test String(take!(BUF)) == "one-photon Compton scattering"
@@ -78,8 +79,8 @@ BUF = IOBuffer()
 end
 @testset "particle content" begin
     proc = Compton()
-    @test incoming_particles(proc) == (Electron(), Photon())
-    @test outgoing_particles(proc) == (Electron(), Photon())
+    @test incoming_particles(proc) == (QEDbase.Electron(), QEDbase.Photon())
+    @test outgoing_particles(proc) == (QEDbase.Electron(), QEDbase.Photon())
     @test number_incoming_particles(proc) == 2
     @test number_outgoing_particles(proc) == 2
 end

--- a/test/processes/one_photon_compton/process.jl
+++ b/test/processes/one_photon_compton/process.jl
@@ -1,6 +1,6 @@
 using QEDprocesses
 using Random
-import QEDbase
+using QEDbase: QEDbase
 using QEDcore
 
 POLS = [QEDbase.PolX(), QEDbase.PolY(), QEDbase.AllPol()]
@@ -12,10 +12,14 @@ BUF = IOBuffer()
 @testset "constructor" begin
     @testset "default" begin
         proc = Compton()
-        @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) == QEDbase.AllPol()
-        @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) == QEDbase.AllSpin()
-        @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) == QEDbase.AllPol()
-        @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) == QEDbase.AllSpin()
+        @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) ==
+            QEDbase.AllPol()
+        @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) ==
+            QEDbase.AllSpin()
+        @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) ==
+            QEDbase.AllPol()
+        @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) ==
+            QEDbase.AllSpin()
 
         print(BUF, proc)
         @test String(take!(BUF)) == "one-photon Compton scattering"
@@ -28,10 +32,14 @@ BUF = IOBuffer()
     @testset "in_pol" begin
         @testset "$pol" for pol in POLS
             proc = Compton(pol)
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) == QEDbase.AllSpin()
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) == pol
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) == QEDbase.AllSpin()
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) == QEDbase.AllPol()
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) ==
+                QEDbase.AllSpin()
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) ==
+                pol
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) ==
+                QEDbase.AllSpin()
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) ==
+                QEDbase.AllPol()
 
             print(BUF, proc)
             @test String(take!(BUF)) == "one-photon Compton scattering"
@@ -45,10 +53,14 @@ BUF = IOBuffer()
     @testset "in_pol+out_pol" begin
         @testset "$in_pol, $out_pol" for (in_pol, out_pol) in POL_COMBINATIONS
             proc = Compton(in_pol, out_pol)
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) == QEDbase.AllSpin()
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) == in_pol
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) == QEDbase.AllSpin()
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) == out_pol
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) ==
+                QEDbase.AllSpin()
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) ==
+                in_pol
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) ==
+                QEDbase.AllSpin()
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) ==
+                out_pol
 
             print(BUF, proc)
             @test String(take!(BUF)) == "one-photon Compton scattering"
@@ -63,10 +75,14 @@ BUF = IOBuffer()
             in_spin, in_pol, out_spin, out_pol
         ) in POL_AND_SPIN_COMBINATIONS
             proc = Compton(in_spin, in_pol, out_spin, out_pol)
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) == in_spin
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) == in_pol
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) == out_spin
-            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) == out_pol
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Incoming()) ==
+                in_spin
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Incoming()) ==
+                in_pol
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Electron(), QEDbase.Outgoing()) ==
+                out_spin
+            @test QEDprocesses._spin_or_pol(proc, QEDbase.Photon(), QEDbase.Outgoing()) ==
+                out_pol
 
             print(BUF, proc)
             @test String(take!(BUF)) == "one-photon Compton scattering"

--- a/test/propagators.jl
+++ b/test/propagators.jl
@@ -1,5 +1,5 @@
 using Random
-import QEDbase
+using QEDbase: QEDbase
 using QEDcore
 using QEDprocesses
 

--- a/test/propagators.jl
+++ b/test/propagators.jl
@@ -1,5 +1,6 @@
 using Random
-using QEDbase
+import QEDbase
+using QEDcore
 using QEDprocesses
 
 RNG = MersenneTwister(137137)
@@ -10,14 +11,14 @@ function _rand_momentum(rng::AbstractRNG)
     return SFourMomentum(rand(rng, 4))
 end
 
-groundtruth_propagator(::Photon, mom) = one(eltype(mom)) / (mom * mom)
-function groundtruth_propagator(particle::FermionLike, mom)
-    return (slashed(mom) + mass(particle) * one(DiracMatrix)) /
-           (mom * mom - mass(particle)^2)
+groundtruth_propagator(::QEDbase.Photon, mom) = one(eltype(mom)) / (mom * mom)
+function groundtruth_propagator(particle::QEDbase.FermionLike, mom)
+    return (slashed(mom) + QEDbase.mass(particle) * one(DiracMatrix)) /
+           (mom * mom - QEDbase.mass(particle)^2)
 end
 
 @testset "propagators" begin
-    @testset "$P" for P in (Electron(), Positron(), Photon())
+    @testset "$P" for P in (QEDbase.Electron(), QEDbase.Positron(), QEDbase.Photon())
         mom = _rand_momentum(RNG)
         groundtruth = groundtruth_propagator(P, mom)
         test_prop = propagator(P, mom)

--- a/test/test_implementation/TestImplementation.jl
+++ b/test/test_implementation/TestImplementation.jl
@@ -26,7 +26,8 @@ export TestProcess, TestProcess_FAIL
 export TestPhasespaceDef, TestPhasespaceDef_FAIL
 
 using Random
-using QEDbase
+import QEDbase
+using QEDcore
 using QEDprocesses
 using StaticArrays
 

--- a/test/test_implementation/TestImplementation.jl
+++ b/test/test_implementation/TestImplementation.jl
@@ -26,7 +26,7 @@ export TestProcess, TestProcess_FAIL
 export TestPhasespaceDef, TestPhasespaceDef_FAIL
 
 using Random
-import QEDbase
+using QEDbase: QEDbase
 using QEDcore
 using QEDprocesses
 using StaticArrays

--- a/test/test_implementation/groundtruths.jl
+++ b/test/test_implementation/groundtruths.jl
@@ -59,8 +59,8 @@ end
 Test implementation of the phase space factor. Return the inverse of the product of the energies of all external particles.
 """
 function _groundtruth_phase_space_factor(in_ps, out_ps)
-    en_in = getE.(in_ps)
-    en_out = getE.(out_ps)
+    en_in = QEDbase.getE.(in_ps)
+    en_out = QEDbase.getE.(out_ps)
     return 1 / (prod(en_in) * prod(en_out))
 end
 

--- a/test/test_implementation/test_process.jl
+++ b/test/test_implementation/test_process.jl
@@ -1,6 +1,6 @@
 # dummy particles
-struct TestParticleFermion <: FermionLike end
-struct TestParticleBoson <: BosonLike end
+struct TestParticleFermion <: QEDbase.FermionLike end
+struct TestParticleBoson <: QEDbase.BosonLike end
 
 const PARTICLE_SET = [TestParticleFermion(), TestParticleBoson()]
 
@@ -79,7 +79,7 @@ struct TestPhasespaceDef_FAIL <: AbstractPhasespaceDefinition end
 # dummy implementation of the process interface
 
 function QEDprocesses._incident_flux(in_psp::InPhaseSpacePoint{<:TestProcess,<:TestModel})
-    return _groundtruth_incident_flux(momenta(in_psp, Incoming()))
+    return _groundtruth_incident_flux(momenta(in_psp, QEDbase.Incoming()))
 end
 
 function QEDprocesses._averaging_norm(proc::TestProcess)
@@ -87,22 +87,22 @@ function QEDprocesses._averaging_norm(proc::TestProcess)
 end
 
 function QEDprocesses._matrix_element(psp::PhaseSpacePoint{<:TestProcess,TestModel})
-    in_ps = momenta(psp, Incoming())
-    out_ps = momenta(psp, Outgoing())
+    in_ps = momenta(psp, QEDbase.Incoming())
+    out_ps = momenta(psp, QEDbase.Outgoing())
     return _groundtruth_matrix_element(in_ps, out_ps)
 end
 
 function QEDprocesses._is_in_phasespace(psp::PhaseSpacePoint{<:TestProcess,TestModel})
-    in_ps = momenta(psp, Incoming())
-    out_ps = momenta(psp, Outgoing())
+    in_ps = momenta(psp, QEDbase.Incoming())
+    out_ps = momenta(psp, QEDbase.Outgoing())
     return _groundtruth_is_in_phasespace(in_ps, out_ps)
 end
 
 function QEDprocesses._phase_space_factor(
     psp::PhaseSpacePoint{<:TestProcess,TestModel,TestPhasespaceDef}
 )
-    in_ps = momenta(psp, Incoming())
-    out_ps = momenta(psp, Outgoing())
+    in_ps = momenta(psp, QEDbase.Incoming())
+    out_ps = momenta(psp, QEDbase.Outgoing())
     return _groundtruth_phase_space_factor(in_ps, out_ps)
 end
 
@@ -127,5 +127,5 @@ end
 function QEDprocesses._total_probability(
     in_psp::InPhaseSpacePoint{<:TestProcess,<:TestModel,<:TestPhasespaceDef}
 )
-    return _groundtruth_total_probability(momenta(in_psp, Incoming()))
+    return _groundtruth_total_probability(momenta(in_psp, QEDbase.Incoming()))
 end


### PR DESCRIPTION
This opts out the `QEDbase` namespace and adds the dependency on `QEDcore`. 

This is part of the general restructuring of `QED.jl`, see https://github.com/QEDjl-project/QED.jl/issues/35 for details. 