### PR TITLE
bump dev version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,13 @@
 name = "QEDprocesses"
 uuid = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
-authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
-version = "0.1.0"
+authors = [
+    "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
+    "Simeon Ehrig",
+    "Klaus Steiniger",
+    "Tom Jungnickel",
+    "Anton Reinhard",
+]
+version = "0.2.0-DEV"
 
 [deps]
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"


### PR DESCRIPTION
Bumps the current version of QEDprocesses to a 0.2-DEV.

Reason: during the current refac, we need the current dev registered to have working integration tests. 