### PR TITLE
Qualify total_cross_section calls

### DIFF
--- a/test/cross_sections.jl
+++ b/test/cross_sections.jl
@@ -71,8 +71,8 @@ TESTPSDEF = TestImplementation.TestPhasespaceDef()
             )
 
             groundtruth = TestImplementation._groundtruth_total_cross_section(p_in_phys)
-            totCS_on_moms = total_cross_section(IN_PS_POINT)
-            totCS_on_coords = total_cross_section(IN_PS_POINT_COORDS)
+            totCS_on_moms = QEDprocesses.total_cross_section(IN_PS_POINT)
+            totCS_on_coords = QEDprocesses.total_cross_section(IN_PS_POINT_COORDS)
 
             @test isapprox(totCS_on_moms, groundtruth, atol=ATOL, rtol=RTOL)
             @test isapprox(totCS_on_coords, groundtruth, atol=ATOL, rtol=RTOL)

--- a/test/processes/one_photon_compton/perturbative.jl
+++ b/test/processes/one_photon_compton/perturbative.jl
@@ -139,7 +139,7 @@ end
 
                 IN_COORDS = (omega,)
                 groundtruth = klein_nishina_total_cross_section(IN_COORDS)
-                test_val = @inferred total_cross_section(
+                test_val = @inferred QEDprocesses.total_cross_section(
                     InPhaseSpacePoint(PROC, MODEL, PS_DEF, IN_COORDS)
                 )
                 @test isapprox(test_val, groundtruth, atol=ATOL, rtol=RTOL)
@@ -148,7 +148,7 @@ end
                                                Iterators.product(COS_THETAS, PHIS)
                     OUT_COORDS = (cos_theta, phi)
 
-                    test_val = @inferred total_cross_section(
+                    test_val = @inferred QEDprocesses.total_cross_section(
                         PhaseSpacePoint(PROC, MODEL, PS_DEF, IN_COORDS, OUT_COORDS)
                     )
                     @test isapprox(test_val, groundtruth, atol=ATOL, rtol=RTOL)
@@ -157,7 +157,7 @@ end
                         PhaseSpacePoint(PROC, MODEL, PS_DEF, IN_COORDS, OUT_COORDS),
                         QEDbase.Outgoing(),
                     )
-                    @test_throws MethodError total_cross_section(
+                    @test_throws MethodError QEDprocesses.total_cross_section(
                         OutPhaseSpacePoint(PROC, MODEL, PS_DEF, out_moms)
                     )
                 end


### PR DESCRIPTION
Since `total_cross_section` moves to QEDbase, we need to qualify the calls here for now in order for integration tests to work.

Once we remove the implementation here, the `QEDbase.` calls will automatically fail and need to be removed as well.