### PR TITLE
Bump dev version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ authors = [
     "Tom Jungnickel",
     "Anton Reinhard",
 ]
-version = "0.2.0-DEV"
+version = "0.1.1-DEV"
 
 [deps]
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,13 @@
 name = "QEDprocesses"
 uuid = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
-authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
-version = "0.1.0"
+authors = [
+    "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
+    "Simeon Ehrig",
+    "Klaus Steiniger",
+    "Tom Jungnickel",
+    "Anton Reinhard",
+]
+version = "0.2.0-DEV"
 
 [deps]
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"


### PR DESCRIPTION
This bumps the version of the dev-branch to 0.1.1-DEV. 

This in only for test purposes and should not me released in the general registry. 
It only ticks up the patch version to not break compats upstream. 