### PR TITLE
GenericQEDProcess

### DIFF
--- a/.github/workflows/formatter.yaml
+++ b/.github/workflows/formatter.yaml
@@ -9,7 +9,7 @@ jobs:
       - name: install Julia
         uses: julia-actions/setup-julia@v1
         with:
-          version: 1.10
+          version: "1.10"
       - name: Install Julia requirements
         run: julia --project=${GITHUB_WORKSPACE}/.formatting -e 'import Pkg; Pkg.instantiate()'
       - name: Check code style

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -9,7 +9,7 @@ export PerturbativeQED
 
 # specific scattering processes
 export Compton, omega_prime
-export GenericQEDProcess, isphysical
+export ScatteringProcess, isphysical
 
 using QEDbase
 using QEDcore

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -4,14 +4,12 @@ module QEDprocesses
 export ALPHA,
     ALPHA_SQUARE, ELEMENTARY_CHARGE, ELEMENTARY_CHARGE_SQUARE, ELECTRONMASS, ONE_OVER_FOURPI
 
-# propagator
-export propagator
-
 # specific compute models
 export PerturbativeQED
 
 # specific scattering processes
 export Compton, omega_prime
+export GenericQEDProcess, isphysical
 
 using QEDbase
 using QEDcore
@@ -22,6 +20,11 @@ include("constants.jl")
 include("utils.jl")
 
 include("models/models.jl")
+
+# generic qed process
+include("processes/generic_process/utility.jl")
+include("processes/generic_process/process.jl")
+include("processes/generic_process/perturbative/cross_section.jl")
 
 # one photon compton
 include("processes/one_photon_compton/process.jl")

--- a/src/models/perturbative_qed.jl
+++ b/src/models/perturbative_qed.jl
@@ -28,3 +28,17 @@ function Base.show(io::IO, ::PerturbativeQED)
     print(io, "perturbative QED")
     return nothing
 end
+
+"""
+    isphysical(proc::AbstractProcessDefinition, model::PerturbativeQED)
+
+A utility function that returns whether a given `AbstractProcessDefinition` conserves the number and charge of fermions and has at least 2 participating particles.
+"""
+function isphysical(proc::AbstractProcessDefinition, ::PerturbativeQED)
+    return (
+        number_particles(proc, Incoming(), Electron()) +
+        number_particles(proc, Outgoing(), Positron()) ==
+        number_particles(proc, Incoming(), Positron()) +
+        number_particles(proc, Outgoing(), Electron())
+    ) && number_particles(proc, Incoming()) + number_particles(proc, Outgoing()) >= 2
+end

--- a/src/processes/generic_process/perturbative/cross_section.jl
+++ b/src/processes/generic_process/perturbative/cross_section.jl
@@ -1,0 +1,22 @@
+# None of these functions are currently implemented.
+# They will be implemented using the QEDFeynmanDiagrams project when that is released.
+
+#=
+function QEDbase._incident_flux(psp::InPhaseSpacePoint{<:GenericQEDProcess,PerturbativeQED}) end
+
+function QEDbase._matrix_element(psp::PhaseSpacePoint{<:GenericQEDProcess,PerturbativeQED})
+    proc = process(psp)
+    # by using FeynmanDiagramGenerator.jl
+    return sqrt(proc.matrix_element_squared(psp))
+end
+
+function QEDbase._averaging_norm(proc::<:GenericQEDProcess) end
+
+function QEDbase._is_in_phasespace(psp::PhaseSpacePoint{<:GenericQEDProcess,PerturbativeQED}) end
+
+function QEDbase._phase_space_factor(
+    psp::PhaseSpacePoint{<:GenericQEDProcess,PerturbativeQED,CustomPhasespaceDefinition}
+) end
+
+function QEDbase._total_probability(in_psp::InPhaseSpacePoint{<:GenericQEDProcess,PerturbativeQED}) end
+=#

--- a/src/processes/generic_process/perturbative/cross_section.jl
+++ b/src/processes/generic_process/perturbative/cross_section.jl
@@ -2,21 +2,19 @@
 # They will be implemented using the QEDFeynmanDiagrams project when that is released.
 
 #=
-function QEDbase._incident_flux(psp::InPhaseSpacePoint{<:GenericQEDProcess,PerturbativeQED}) end
+function QEDbase._incident_flux(psp::InPhaseSpacePoint{<:ScatteringProcess,PerturbativeQED}) end
 
-function QEDbase._matrix_element(psp::PhaseSpacePoint{<:GenericQEDProcess,PerturbativeQED})
+function QEDbase._matrix_element_squared(psp::PhaseSpacePoint{<:ScatteringProcess,PerturbativeQED})
     proc = process(psp)
     # by using FeynmanDiagramGenerator.jl
-    return sqrt(proc.matrix_element_squared(psp))
+    return proc.matrix_element_squared(psp)
 end
 
-function QEDbase._averaging_norm(proc::<:GenericQEDProcess) end
+function QEDbase._averaging_norm(proc::<:ScatteringProcess) end
 
-function QEDbase._is_in_phasespace(psp::PhaseSpacePoint{<:GenericQEDProcess,PerturbativeQED}) end
+function QEDbase._is_in_phasespace(psp::PhaseSpacePoint{<:ScatteringProcess,PerturbativeQED}) end
 
 function QEDbase._phase_space_factor(
-    psp::PhaseSpacePoint{<:GenericQEDProcess,PerturbativeQED,CustomPhasespaceDefinition}
+    psp::PhaseSpacePoint{<:ScatteringProcess,PerturbativeQED,CustomPhasespaceDefinition}
 ) end
-
-function QEDbase._total_probability(in_psp::InPhaseSpacePoint{<:GenericQEDProcess,PerturbativeQED}) end
 =#

--- a/src/processes/generic_process/process.jl
+++ b/src/processes/generic_process/process.jl
@@ -1,15 +1,30 @@
 """
-    GenericQEDProcess <: AbstractProcessDefinition
+    ScatteringProcess <: AbstractProcessDefinition
 
-An implementation of the `AbstractProcessDefinition` interface for a generic particle process in QED
-with any number of incoming and outgoing particles, and any combination of spins or polarizations for the particles set.
+Generic implementation for scattering processes of arbitrary particles. Currently, only calculations in combination with `PerturbativeQED` are supported. 
+However, this is supposed to describe scattering processes with any number of incoming and outgoing particles, and any combination of spins or polarizations for the particles.
 
-The [`isphysical`](@ref) function can be used to check whether the process is possible in QED.
+The [`isphysical`](@ref) function can be used to check whether the process is possible in perturbative QED.
 
-!!! note
+!!! warning  
     The computation of cross sections and probabilities is currently unimplemented.
+
+## Constructors
+
+    ScatteringProcess(
+        in_particles::Tuple{AbstractParticleType},
+        out_particles::Tuple{AbstractParticleType},
+        [in_sp::Tuple{AbstractSpinOrPolarization},
+        out_sp::Tuple{AbstractSpinOrPolarization}]
+    )
+
+Constructor for a ScatteringProcess with the given incoming and outgoing particles and their respective spins and pols.
+The constructor asserts that the particles are compatible with their respective spins and polarizations. If the assertion fails, an 
+`InvalidInputError` is thrown.
+
+The `in_sp` and `out_sp` parameters can be omitted in which case all spins and polarizations will be set to `AllSpin` and `AllPol` for every fermion and boson, respectively.
 """
-struct GenericQEDProcess{INT,OUTT,INSP,OUTSP} <:
+struct ScatteringProcess{INT,OUTT,INSP,OUTSP} <:
        AbstractProcessDefinition where {INT<:Tuple,OUTT<:Tuple,INSP<:Tuple,OUTSP<:Tuple}
     incoming_particles::INT
     outgoing_particles::OUTT
@@ -17,46 +32,30 @@ struct GenericQEDProcess{INT,OUTT,INSP,OUTSP} <:
     incoming_spin_pols::INSP
     outgoing_spin_pols::OUTSP
 
-    """
-        GenericQEDProcess(
-            in_particles::Tuple{AbstractParticleType},
-            out_particles::Tuple{AbstractParticleType},
-            in_sp::Tuple{AbstractSpinOrPolarization},
-            out_sp::Tuple{AbstractSpinOrPolarization}
-        )
-
-    Constructor for a GenericQEDProcess with the given incoming and outgoing particles and their respective spins and pols.
-    The constructor asserts that the particles are compatible with their respective spins and polarizations. If the assertion fails, an 
-    `InvalidInputError` is thrown.
-    """
-    function GenericQEDProcess(
-        in_particles::INT, out_particles::OUTT, in_spin_pols::INSP, out_spin_pols::OUTSP
-    ) where {INT<:Tuple,OUTT<:Tuple,INSP<:Tuple,OUTSP<:Tuple}
-        _assert_particle_type_tuple(in_particles)
-        _assert_particle_type_tuple(out_particles)
-
+    function ScatteringProcess(
+        in_particles::NTuple{I,AbstractParticleType},
+        out_particles::NTuple{O,AbstractParticleType},
+        in_spin_pols::NTuple{I,AbstractSpinOrPolarization},
+        out_spin_pols::NTuple{O,AbstractSpinOrPolarization},
+    ) where {I,O}
         _assert_spin_pol_particle_compatability(in_particles, in_spin_pols)
         _assert_spin_pol_particle_compatability(out_particles, out_spin_pols)
 
-        return new{INT,OUTT,INSP,OUTSP}(
+        return new{
+            typeof(in_particles),
+            typeof(out_particles),
+            typeof(in_spin_pols),
+            typeof(out_spin_pols),
+        }(
             in_particles, out_particles, in_spin_pols, out_spin_pols
         )
     end
 end
 
-"""
-    GenericQEDProcess(in_particles::Tuple{AbstractParticleType}, out_particles::Tuple{AbstractParticleType})
-
-Constructor for a GenericQEDProcess, setting `AllPol` and `AllSpin` for every boson and fermion, respectively.
-"""
-function GenericQEDProcess(
-    in_particles::INT, out_particles::OUTT
-) where {INT<:Tuple,OUTT<:Tuple}
-    # this will be called again by the default constructor, but it produces a nicer warning here
-    # than the following spin/pol generation failing because is_fermion or is_boson isn't defined on not allowed types
-    _assert_particle_type_tuple(in_particles)
-    _assert_particle_type_tuple(out_particles)
-
+function ScatteringProcess(
+    in_particles::NTuple{I,AbstractParticleType},
+    out_particles::NTuple{O,AbstractParticleType},
+) where {I,O}
     in_spin_pols = ntuple(
         x -> is_fermion(in_particles[x]) ? AllSpin() : AllPolarization(),
         length(in_particles),
@@ -65,37 +64,23 @@ function GenericQEDProcess(
         x -> is_fermion(out_particles[x]) ? AllSpin() : AllPolarization(),
         length(out_particles),
     )
-    return GenericQEDProcess(in_particles, out_particles, in_spin_pols, out_spin_pols)
+    return ScatteringProcess(in_particles, out_particles, in_spin_pols, out_spin_pols)
 end
 
-function QEDbase.incoming_particles(proc::GenericQEDProcess)
+function QEDbase.incoming_particles(proc::ScatteringProcess)
     return proc.incoming_particles
 end
-function QEDbase.outgoing_particles(proc::GenericQEDProcess)
+function QEDbase.outgoing_particles(proc::ScatteringProcess)
     return proc.outgoing_particles
 end
-function QEDbase.incoming_spin_pols(proc::GenericQEDProcess)
+function QEDbase.incoming_spin_pols(proc::ScatteringProcess)
     return proc.incoming_spin_pols
 end
-function QEDbase.outgoing_spin_pols(proc::GenericQEDProcess)
+function QEDbase.outgoing_spin_pols(proc::ScatteringProcess)
     return proc.outgoing_spin_pols
 end
 
-"""
-    isphysical(proc::GenericQEDProcess)
-
-A utility function that returns whether a given GenericQEDProcess conserves the number and charge of fermions and has at least 2 participating particles.
-"""
-function isphysical(proc::GenericQEDProcess)
-    return (
-        number_particles(proc, Incoming(), Electron()) +
-        number_particles(proc, Outgoing(), Positron()) ==
-        number_particles(proc, Incoming(), Positron()) +
-        number_particles(proc, Outgoing(), Electron())
-    ) && number_particles(proc, Incoming()) + number_particles(proc, Outgoing()) >= 2
-end
-
-function Base.show(io::IO, proc::GenericQEDProcess)
+function Base.show(io::IO, proc::ScatteringProcess)
     print(io, "generic QED process \"")
     for p in incoming_particles(proc)
         print(io, _particle_to_letter(p))
@@ -108,7 +93,7 @@ function Base.show(io::IO, proc::GenericQEDProcess)
     return nothing
 end
 
-function Base.show(io::IO, ::MIME"text/plain", proc::GenericQEDProcess)
+function Base.show(io::IO, ::MIME"text/plain", proc::ScatteringProcess)
     println(io, "generic QED process")
     for dir in (Incoming(), Outgoing())
         first = true

--- a/src/processes/generic_process/process.jl
+++ b/src/processes/generic_process/process.jl
@@ -1,24 +1,71 @@
-mutable struct GenericQEDProcess{INT,OUTT,INSP,OUTSP} <: AbstractProcessDefinition where {
-    INT<:Tuple,OUTT<:Tuple,INSP<:Tuple,OUTSP<:Tuple
-}
+"""
+    GenericQEDProcess <: AbstractProcessDefinition
+
+An implementation of the `AbstractProcessDefinition` interface for a generic particle process in QED
+with any number of incoming and outgoing particles, and any combination of spins or polarizations for the particles set.
+
+The [`isphysical`](@ref) function can be used to check whether the process is possible in QED.
+
+!!! note
+    The computation of cross sections and probabilities is currently unimplemented.
+"""
+struct GenericQEDProcess{INT,OUTT,INSP,OUTSP} <:
+       AbstractProcessDefinition where {INT<:Tuple,OUTT<:Tuple,INSP<:Tuple,OUTSP<:Tuple}
     incoming_particles::INT
     outgoing_particles::OUTT
 
-    incoming_spins_pols::INSP
-    outgoing_spins_pols::OUTSP
+    incoming_spin_pols::INSP
+    outgoing_spin_pols::OUTSP
 
-    matrix_element_squared::Function
+    """
+        GenericQEDProcess(
+            in_particles::Tuple{AbstractParticleType},
+            out_particles::Tuple{AbstractParticleType},
+            in_sp::Tuple{AbstractSpinOrPolarization},
+            out_sp::Tuple{AbstractSpinOrPolarization}
+        )
 
+    Constructor for a GenericQEDProcess with the given incoming and outgoing particles and their respective spins and pols.
+    The constructor asserts that the particles are compatible with their respective spins and polarizations. If the assertion fails, an 
+    `InvalidInputError` is thrown.
+    """
     function GenericQEDProcess(
-        in_particles::INT, out_particles::OUTT, in_sp::INSP, out_sp::OUTSP
+        in_particles::INT, out_particles::OUTT, in_spin_pols::INSP, out_spin_pols::OUTSP
     ) where {INT<:Tuple,OUTT<:Tuple,INSP<:Tuple,OUTSP<:Tuple}
         _assert_particle_type_tuple(in_particles)
         _assert_particle_type_tuple(out_particles)
 
+        _assert_spin_pol_particle_compatability(in_particles, in_spin_pols)
+        _assert_spin_pol_particle_compatability(out_particles, out_spin_pols)
+
         return new{INT,OUTT,INSP,OUTSP}(
-            in_particles, out_particles, in_sp, out_sp, _ -> error("unimplemented")
+            in_particles, out_particles, in_spin_pols, out_spin_pols
         )
     end
+end
+
+"""
+    GenericQEDProcess(in_particles::Tuple{AbstractParticleType}, out_particles::Tuple{AbstractParticleType})
+
+Constructor for a GenericQEDProcess, setting `AllPol` and `AllSpin` for every boson and fermion, respectively.
+"""
+function GenericQEDProcess(
+    in_particles::INT, out_particles::OUTT
+) where {INT<:Tuple,OUTT<:Tuple}
+    # this will be called again by the default constructor, but it produces a nicer warning here
+    # than the following spin/pol generation failing because is_fermion or is_boson isn't defined on not allowed types
+    _assert_particle_type_tuple(in_particles)
+    _assert_particle_type_tuple(out_particles)
+
+    in_spin_pols = ntuple(
+        x -> is_fermion(in_particles[x]) ? AllSpin() : AllPolarization(),
+        length(in_particles),
+    )
+    out_spin_pols = ntuple(
+        x -> is_fermion(out_particles[x]) ? AllSpin() : AllPolarization(),
+        length(out_particles),
+    )
+    return GenericQEDProcess(in_particles, out_particles, in_spin_pols, out_spin_pols)
 end
 
 function QEDbase.incoming_particles(proc::GenericQEDProcess)
@@ -28,10 +75,10 @@ function QEDbase.outgoing_particles(proc::GenericQEDProcess)
     return proc.outgoing_particles
 end
 function QEDbase.incoming_spin_pols(proc::GenericQEDProcess)
-    return proc.incoming_spins_pols
+    return proc.incoming_spin_pols
 end
 function QEDbase.outgoing_spin_pols(proc::GenericQEDProcess)
-    return proc.outgoing_spins_pols
+    return proc.outgoing_spin_pols
 end
 
 """
@@ -46,4 +93,35 @@ function isphysical(proc::GenericQEDProcess)
         number_particles(proc, Incoming(), Positron()) +
         number_particles(proc, Outgoing(), Electron())
     ) && number_particles(proc, Incoming()) + number_particles(proc, Outgoing()) >= 2
+end
+
+function Base.show(io::IO, proc::GenericQEDProcess)
+    print(io, "generic QED process \"")
+    for p in incoming_particles(proc)
+        print(io, _particle_to_letter(p))
+    end
+    print(io, " -> ")
+    for p in outgoing_particles(proc)
+        print(io, _particle_to_letter(p))
+    end
+    print(io, "\"")
+    return nothing
+end
+
+function Base.show(io::IO, ::MIME"text/plain", proc::GenericQEDProcess)
+    println(io, "generic QED process")
+    for dir in (Incoming(), Outgoing())
+        first = true
+        for (p, sp) in zip(particles(proc, dir), spin_pols(proc, dir))
+            if !first
+                print(io, ", ")
+            else
+                print(io, "    $(dir): ")
+                first = false
+            end
+            print(io, "$(p) ($(sp))")
+        end
+        println(io)
+    end
+    return nothing
 end

--- a/src/processes/generic_process/process.jl
+++ b/src/processes/generic_process/process.jl
@@ -1,0 +1,49 @@
+mutable struct GenericQEDProcess{INT,OUTT,INSP,OUTSP} <: AbstractProcessDefinition where {
+    INT<:Tuple,OUTT<:Tuple,INSP<:Tuple,OUTSP<:Tuple
+}
+    incoming_particles::INT
+    outgoing_particles::OUTT
+
+    incoming_spins_pols::INSP
+    outgoing_spins_pols::OUTSP
+
+    matrix_element_squared::Function
+
+    function GenericQEDProcess(
+        in_particles::INT, out_particles::OUTT, in_sp::INSP, out_sp::OUTSP
+    ) where {INT<:Tuple,OUTT<:Tuple,INSP<:Tuple,OUTSP<:Tuple}
+        _assert_particle_type_tuple(in_particles)
+        _assert_particle_type_tuple(out_particles)
+
+        return new{INT,OUTT,INSP,OUTSP}(
+            in_particles, out_particles, in_sp, out_sp, _ -> error("unimplemented")
+        )
+    end
+end
+
+function QEDbase.incoming_particles(proc::GenericQEDProcess)
+    return proc.incoming_particles
+end
+function QEDbase.outgoing_particles(proc::GenericQEDProcess)
+    return proc.outgoing_particles
+end
+function QEDbase.incoming_spin_pols(proc::GenericQEDProcess)
+    return proc.incoming_spins_pols
+end
+function QEDbase.outgoing_spin_pols(proc::GenericQEDProcess)
+    return proc.outgoing_spins_pols
+end
+
+"""
+    isphysical(proc::GenericQEDProcess)
+
+A utility function that returns whether a given GenericQEDProcess conserves the number and charge of fermions and has at least 2 participating particles.
+"""
+function isphysical(proc::GenericQEDProcess)
+    return (
+        number_particles(proc, Incoming(), Electron()) +
+        number_particles(proc, Outgoing(), Positron()) ==
+        number_particles(proc, Incoming(), Positron()) +
+        number_particles(proc, Outgoing(), Electron())
+    ) && number_particles(proc, Incoming()) + number_particles(proc, Outgoing()) >= 2
+end

--- a/src/processes/generic_process/utility.jl
+++ b/src/processes/generic_process/utility.jl
@@ -5,7 +5,41 @@ end
 function _assert_particle_type_tuple(t::Any)
     throw(
         InvalidInputError(
-            "invalid input, provide a tuple of AbstractParticleTypes to construct a QEDProcess",
+            "invalid input, provide a tuple of AbstractParticleTypes to construct a GenericQEDProcess",
         ),
     )
 end
+
+_assert_spin_pol_particle_compatability(::Tuple{}, ::Tuple{}) = nothing
+function _assert_spin_pol_particle_compatability(::Tuple{}, ::Tuple{Vararg})
+    throw(InvalidInputError("more spins/pols than particles given"))
+end
+function _assert_spin_pol_particle_compatability(::Tuple{Vararg}, ::Tuple{})
+    throw(InvalidInputError("more particles than spins/pols given"))
+end
+
+function _assert_spin_pol_particle_compatability(
+    particles::Tuple{AbstractParticleType,Vararg},
+    spin_pols::Tuple{AbstractSpinOrPolarization,Vararg},
+)
+    if is_fermion(particles[1]) && !(spin_pols[1] isa AbstractSpin)
+        throw(
+            InvalidInputError(
+                "particle \"$(particles[1])\" is a fermion and should have a spin, but has \"$(spin_pols[1])\"",
+            ),
+        )
+    end
+    if is_boson(particles[1]) && !(spin_pols[1] isa AbstractPolarization)
+        throw(
+            InvalidInputError(
+                "particle \"$(particles[1])\" is a boson and should have a polarization, but has \"$(spin_pols[1])\"",
+            ),
+        )
+    end
+    return _assert_spin_pol_particle_compatability(particles[2:end], spin_pols[2:end])
+end
+
+# this should move to QEDbase as part of the interface, see https://github.com/QEDjl-project/QEDbase.jl/issues/114
+_particle_to_letter(::Electron) = "e"
+_particle_to_letter(::Positron) = "p"
+_particle_to_letter(::Photon) = "k"

--- a/src/processes/generic_process/utility.jl
+++ b/src/processes/generic_process/utility.jl
@@ -1,23 +1,8 @@
-_assert_particle_type_tuple(::Tuple{}) = nothing
-function _assert_particle_type_tuple(t::Tuple{AbstractParticleType,Vararg})
-    return _assert_particle_type_tuple(t[2:end])
-end
-function _assert_particle_type_tuple(t::Any)
-    throw(
-        InvalidInputError(
-            "invalid input, provide a tuple of AbstractParticleTypes to construct a GenericQEDProcess",
-        ),
-    )
-end
-
+# recursion success, all particles are compatible with their spin/pol
 _assert_spin_pol_particle_compatability(::Tuple{}, ::Tuple{}) = nothing
-function _assert_spin_pol_particle_compatability(::Tuple{}, ::Tuple{Vararg})
-    throw(InvalidInputError("more spins/pols than particles given"))
-end
-function _assert_spin_pol_particle_compatability(::Tuple{Vararg}, ::Tuple{})
-    throw(InvalidInputError("more particles than spins/pols given"))
-end
 
+# recursion base case: check first particle against first spin/pol, then recurse
+# note: the length of the tuples is expected to be the same, the constructor ensures this by using NTuples
 function _assert_spin_pol_particle_compatability(
     particles::Tuple{AbstractParticleType,Vararg},
     spin_pols::Tuple{AbstractSpinOrPolarization,Vararg},

--- a/src/processes/generic_process/utility.jl
+++ b/src/processes/generic_process/utility.jl
@@ -1,0 +1,11 @@
+_assert_particle_type_tuple(::Tuple{}) = nothing
+function _assert_particle_type_tuple(t::Tuple{AbstractParticleType,Vararg})
+    return _assert_particle_type_tuple(t[2:end])
+end
+function _assert_particle_type_tuple(t::Any)
+    throw(
+        InvalidInputError(
+            "invalid input, provide a tuple of AbstractParticleTypes to construct a QEDProcess",
+        ),
+    )
+end

--- a/src/processes/one_photon_compton/perturbative/cross_section.jl
+++ b/src/processes/one_photon_compton/perturbative/cross_section.jl
@@ -3,7 +3,7 @@
 # Implementation of the cross section interface
 #####
 
-function QEDbase._incident_flux(in_psp::InPhaseSpacePoint{<:Compton,<:PerturbativeQED})
+function QEDbase._incident_flux(in_psp::InPhaseSpacePoint{<:Compton,PerturbativeQED})
     return momentum(in_psp, Incoming(), 1) * momentum(in_psp, Incoming(), 2)
 end
 
@@ -39,9 +39,7 @@ end
         )
 end
 
-@inline function QEDbase._is_in_phasespace(
-    psp::PhaseSpacePoint{<:Compton,<:PerturbativeQED}
-)
+@inline function QEDbase._is_in_phasespace(psp::PhaseSpacePoint{<:Compton,PerturbativeQED})
     @inbounds if (
         !isapprox(
             momentum(psp, Incoming(), 1) + momentum(psp, Incoming(), 2),

--- a/src/processes/one_photon_compton/perturbative/total_probability.jl
+++ b/src/processes/one_photon_compton/perturbative/total_probability.jl
@@ -1,4 +1,4 @@
-function QEDbase._total_probability(in_psp::InPhaseSpacePoint{<:Compton,<:PerturbativeQED})
+function QEDbase._total_probability(in_psp::InPhaseSpacePoint{<:Compton,PerturbativeQED})
     omega = getE(momentum(in_psp[Incoming(), 2]))
 
     function func(x)

--- a/test/processes/generic_process/groundtruths.jl
+++ b/test/processes/generic_process/groundtruths.jl
@@ -1,7 +1,7 @@
 POLS = [PolX(), PolY(), AllPol()]
 SPINS = [SpinUp(), SpinDown(), AllSpin()]
 
-function _groundtruth_is_physical(proc::GenericQEDProcess)
+function _groundtruth_is_physical(proc::ScatteringProcess, ::PerturbativeQED)
     incoming_electrons = number_particles(proc, Incoming(), Electron())
     incoming_positrons = number_particles(proc, Incoming(), Positron())
     outgoing_electrons = number_particles(proc, Outgoing(), Electron())

--- a/test/processes/generic_process/groundtruths.jl
+++ b/test/processes/generic_process/groundtruths.jl
@@ -1,0 +1,25 @@
+POLS = [PolX(), PolY(), AllPol()]
+SPINS = [SpinUp(), SpinDown(), AllSpin()]
+
+function _groundtruth_is_physical(proc::GenericQEDProcess)
+    incoming_electrons = number_particles(proc, Incoming(), Electron())
+    incoming_positrons = number_particles(proc, Incoming(), Positron())
+    outgoing_electrons = number_particles(proc, Outgoing(), Electron())
+    outgoing_positrons = number_particles(proc, Outgoing(), Positron())
+
+    return incoming_electrons + outgoing_positrons ==
+           outgoing_electrons + incoming_positrons
+end
+
+function _groundtruth_spin_pols(particles)
+    return ntuple(
+        x -> is_fermion(particles[x]) ? AllSpin() : AllPolarization(), length(particles)
+    )
+end
+
+function _random_spin_pols(RNG, particles)
+    return ntuple(
+        x -> is_fermion(particles[x]) ? rand(RNG, SPINS) : rand(RNG, POLS),
+        length(particles),
+    )
+end

--- a/test/processes/generic_process/process.jl
+++ b/test/processes/generic_process/process.jl
@@ -1,0 +1,197 @@
+using QEDprocesses
+using Random
+using QEDcore
+
+include("groundtruths.jl")
+
+const RNG = MersenneTwister(77697185)
+
+PARTICLES = [Electron(), Positron(), Photon()]
+POLS = [PolX(), PolY(), AllPol()]
+SPINS = [SpinUp(), SpinDown(), AllSpin()]
+POL_AND_SPIN_COMBINATIONS = Iterators.product(SPINS, POLS, SPINS, POLS)
+BUF = IOBuffer()
+
+@testset "constructor" begin
+    @testset "default" begin
+        proc = GenericQEDProcess((Photon(), Electron()), (Photon(), Electron()))
+
+        @test QEDprocesses.spin_pols(proc, Incoming())[1] == AllPol()
+        @test QEDprocesses.spin_pols(proc, Incoming())[2] == AllSpin()
+        @test QEDprocesses.spin_pols(proc, Outgoing())[1] == AllPol()
+        @test QEDprocesses.spin_pols(proc, Outgoing())[2] == AllSpin()
+
+        print(BUF, proc)
+        @test String(take!(BUF)) == "generic QED process \"ke -> ke\""
+
+        show(BUF, MIME"text/plain"(), proc)
+        @test String(take!(BUF)) ==
+            "generic QED process\n    incoming: photon ($(AllPol())), electron ($(AllSpin()))\n    outgoing: photon ($(AllPol())), electron ($(AllSpin()))\n"
+
+        @test isphysical(proc)
+    end
+
+    @testset "all spins+pols" begin
+        @testset "$in_spin, $in_pol, $out_spin, $out_pol" for (
+            in_spin, in_pol, out_spin, out_pol
+        ) in POL_AND_SPIN_COMBINATIONS
+            proc = GenericQEDProcess(
+                (Photon(), Electron()),
+                (Photon(), Electron()),
+                (in_pol, in_spin),
+                (out_pol, out_spin),
+            )
+
+            @test QEDprocesses.spin_pols(proc, Incoming())[1] == in_pol
+            @test QEDprocesses.spin_pols(proc, Incoming())[2] == in_spin
+            @test QEDprocesses.spin_pols(proc, Outgoing())[1] == out_pol
+            @test QEDprocesses.spin_pols(proc, Outgoing())[2] == out_spin
+
+            print(BUF, proc)
+            @test String(take!(BUF)) == "generic QED process \"ke -> ke\""
+
+            show(BUF, MIME"text/plain"(), proc)
+            @test String(take!(BUF)) ==
+                "generic QED process\n    incoming: photon ($(in_pol)), electron ($(in_spin))\n    outgoing: photon ($(out_pol)), electron ($(out_spin))\n"
+
+            @test isphysical(proc)
+        end
+    end
+
+    @testset "invalid types passed" begin
+        struct INVALID_PARTICLE end
+
+        @test_throws "invalid input, provide a tuple of AbstractParticleTypes to construct a GenericQEDProcess" GenericQEDProcess(
+            (INVALID_PARTICLE(), Electron()), (Photon(), Electron())
+        )
+        @test_throws InvalidInputError GenericQEDProcess(
+            (INVALID_PARTICLE(), Electron()), (Photon(), Electron())
+        )
+
+        @test_throws "invalid input, provide a tuple of AbstractParticleTypes to construct a GenericQEDProcess" GenericQEDProcess(
+            (Photon(), Electron()), (Photon(), INVALID_PARTICLE())
+        )
+        @test_throws InvalidInputError GenericQEDProcess(
+            (Photon(), Electron()), (Photon(), INVALID_PARTICLE())
+        )
+    end
+
+    @testset "incompatible spin/pols" begin
+        @test_throws InvalidInputError GenericQEDProcess(
+            (Electron(), Photon()),
+            (Electron(), Photon()),
+            (AllPol(), AllPol()),
+            (AllSpin(), AllPol()),
+        )
+        @test_throws "particle \"electron\" is a fermion and should have a spin, but has \"all polarizations\"" GenericQEDProcess(
+            (Electron(), Photon()),
+            (Electron(), Photon()),
+            (AllPol(), AllPol()),
+            (AllSpin(), AllPol()),
+        )
+
+        @test_throws InvalidInputError GenericQEDProcess(
+            (Electron(), Photon()),
+            (Electron(), Photon()),
+            (AllSpin(), AllSpin()),
+            (AllSpin(), AllPol()),
+        )
+        @test_throws "particle \"photon\" is a boson and should have a polarization, but has \"all spins\"" GenericQEDProcess(
+            (Electron(), Photon()),
+            (Electron(), Photon()),
+            (AllSpin(), AllSpin()),
+            (AllSpin(), AllPol()),
+        )
+    end
+
+    @testset "incompatible number of spins/pols" begin
+        IN_PARTICLES = Tuple(rand(RNG, PARTICLES, 2))
+        OUT_PARTICLES = Tuple(rand(RNG, PARTICLES, 2))
+        @testset "2 particles, 1 spin/pol" begin
+            @test_throws InvalidInputError GenericQEDProcess(
+                IN_PARTICLES,
+                OUT_PARTICLES,
+                _random_spin_pols(RNG, IN_PARTICLES)[1:1],
+                _random_spin_pols(RNG, OUT_PARTICLES),
+            )
+            @test_throws "more particles than spins/pols given" GenericQEDProcess(
+                IN_PARTICLES,
+                OUT_PARTICLES,
+                _random_spin_pols(RNG, IN_PARTICLES)[1:1],
+                _random_spin_pols(RNG, OUT_PARTICLES),
+            )
+
+            @test_throws InvalidInputError GenericQEDProcess(
+                IN_PARTICLES,
+                OUT_PARTICLES,
+                _random_spin_pols(RNG, IN_PARTICLES),
+                _random_spin_pols(RNG, OUT_PARTICLES)[1:1],
+            )
+            @test_throws "more particles than spins/pols given" GenericQEDProcess(
+                IN_PARTICLES,
+                OUT_PARTICLES,
+                _random_spin_pols(RNG, IN_PARTICLES),
+                _random_spin_pols(RNG, OUT_PARTICLES)[1:1],
+            )
+        end
+        @testset "2 particles, 3 spin/pols" begin
+            @test_throws InvalidInputError GenericQEDProcess(
+                IN_PARTICLES,
+                OUT_PARTICLES,
+                (_random_spin_pols(RNG, IN_PARTICLES)..., AllPol()),
+                _random_spin_pols(RNG, OUT_PARTICLES),
+            )
+            @test_throws "more spins/pols than particles given" GenericQEDProcess(
+                IN_PARTICLES,
+                OUT_PARTICLES,
+                (_random_spin_pols(RNG, IN_PARTICLES)..., AllSpin()),
+                _random_spin_pols(RNG, OUT_PARTICLES),
+            )
+
+            @test_throws InvalidInputError GenericQEDProcess(
+                IN_PARTICLES,
+                OUT_PARTICLES,
+                _random_spin_pols(RNG, IN_PARTICLES),
+                (_random_spin_pols(RNG, OUT_PARTICLES)..., AllPol()),
+            )
+            @test_throws "more spins/pols than particles given" GenericQEDProcess(
+                IN_PARTICLES,
+                OUT_PARTICLES,
+                _random_spin_pols(RNG, IN_PARTICLES),
+                (_random_spin_pols(RNG, OUT_PARTICLES)..., AllSpin()),
+            )
+        end
+    end
+end
+
+@testset "particle content" begin
+    @testset "$n -> $m processes" for (n, m) in Base.product((2, 4), (3, 5))
+        IN_PARTICLES = Tuple(rand(RNG, PARTICLES, n))
+        OUT_PARTICLES = Tuple(rand(RNG, PARTICLES, m))
+        proc = GenericQEDProcess(IN_PARTICLES, OUT_PARTICLES)
+        @testset "process $(proc)" begin
+            @test incoming_particles(proc) == IN_PARTICLES
+            @test outgoing_particles(proc) == OUT_PARTICLES
+            @test number_incoming_particles(proc) == n
+            @test number_outgoing_particles(proc) == m
+            @test incoming_spin_pols(proc) == _groundtruth_spin_pols(IN_PARTICLES)
+            @test outgoing_spin_pols(proc) == _groundtruth_spin_pols(OUT_PARTICLES)
+
+            @test isphysical(proc) == _groundtruth_is_physical(proc)
+        end
+
+        IN_SPIN_POLS = _random_spin_pols(RNG, IN_PARTICLES)
+        OUT_SPIN_POLS = _random_spin_pols(RNG, OUT_PARTICLES)
+        proc = GenericQEDProcess(IN_PARTICLES, OUT_PARTICLES, IN_SPIN_POLS, OUT_SPIN_POLS)
+        @testset "process $(proc) with set spins/pols" begin
+            @test incoming_particles(proc) == IN_PARTICLES
+            @test outgoing_particles(proc) == OUT_PARTICLES
+            @test number_incoming_particles(proc) == n
+            @test number_outgoing_particles(proc) == m
+            @test incoming_spin_pols(proc) == IN_SPIN_POLS
+            @test outgoing_spin_pols(proc) == OUT_SPIN_POLS
+
+            @test isphysical(proc) == _groundtruth_is_physical(proc)
+        end
+    end
+end

--- a/test/processes/generic_process/process.jl
+++ b/test/processes/generic_process/process.jl
@@ -61,42 +61,27 @@ BUF = IOBuffer()
     @testset "invalid types passed" begin
         struct INVALID_PARTICLE end
 
-        @test_throws "invalid input, provide a tuple of AbstractParticleTypes to construct a GenericQEDProcess" GenericQEDProcess(
-            (INVALID_PARTICLE(), Electron()), (Photon(), Electron())
-        )
-        @test_throws InvalidInputError GenericQEDProcess(
-            (INVALID_PARTICLE(), Electron()), (Photon(), Electron())
-        )
+        @test_throws InvalidInputError(
+            "invalid input, provide a tuple of AbstractParticleTypes to construct a GenericQEDProcess",
+        ) GenericQEDProcess((INVALID_PARTICLE(), Electron()), (Photon(), Electron()))
 
-        @test_throws "invalid input, provide a tuple of AbstractParticleTypes to construct a GenericQEDProcess" GenericQEDProcess(
-            (Photon(), Electron()), (Photon(), INVALID_PARTICLE())
-        )
-        @test_throws InvalidInputError GenericQEDProcess(
-            (Photon(), Electron()), (Photon(), INVALID_PARTICLE())
-        )
+        @test_throws InvalidInputError(
+            "invalid input, provide a tuple of AbstractParticleTypes to construct a GenericQEDProcess",
+        ) GenericQEDProcess((Photon(), Electron()), (Photon(), INVALID_PARTICLE()))
     end
 
     @testset "incompatible spin/pols" begin
-        @test_throws InvalidInputError GenericQEDProcess(
+        @test_throws InvalidInputError(
+            "particle \"electron\" is a fermion and should have a spin, but has \"all polarizations\"",
+        ) GenericQEDProcess(
             (Electron(), Photon()),
             (Electron(), Photon()),
             (AllPol(), AllPol()),
             (AllSpin(), AllPol()),
         )
-        @test_throws "particle \"electron\" is a fermion and should have a spin, but has \"all polarizations\"" GenericQEDProcess(
-            (Electron(), Photon()),
-            (Electron(), Photon()),
-            (AllPol(), AllPol()),
-            (AllSpin(), AllPol()),
-        )
-
-        @test_throws InvalidInputError GenericQEDProcess(
-            (Electron(), Photon()),
-            (Electron(), Photon()),
-            (AllSpin(), AllSpin()),
-            (AllSpin(), AllPol()),
-        )
-        @test_throws "particle \"photon\" is a boson and should have a polarization, but has \"all spins\"" GenericQEDProcess(
+        @test_throws InvalidInputError(
+            "particle \"photon\" is a boson and should have a polarization, but has \"all spins\"",
+        ) GenericQEDProcess(
             (Electron(), Photon()),
             (Electron(), Photon()),
             (AllSpin(), AllSpin()),
@@ -108,57 +93,32 @@ BUF = IOBuffer()
         IN_PARTICLES = Tuple(rand(RNG, PARTICLES, 2))
         OUT_PARTICLES = Tuple(rand(RNG, PARTICLES, 2))
         @testset "2 particles, 1 spin/pol" begin
-            @test_throws InvalidInputError GenericQEDProcess(
+            @test_throws InvalidInputError("more particles than spins/pols given") GenericQEDProcess(
                 IN_PARTICLES,
                 OUT_PARTICLES,
                 _random_spin_pols(RNG, IN_PARTICLES)[1:1],
                 _random_spin_pols(RNG, OUT_PARTICLES),
             )
-            @test_throws "more particles than spins/pols given" GenericQEDProcess(
-                IN_PARTICLES,
-                OUT_PARTICLES,
-                _random_spin_pols(RNG, IN_PARTICLES)[1:1],
-                _random_spin_pols(RNG, OUT_PARTICLES),
-            )
-
-            @test_throws InvalidInputError GenericQEDProcess(
-                IN_PARTICLES,
-                OUT_PARTICLES,
-                _random_spin_pols(RNG, IN_PARTICLES),
-                _random_spin_pols(RNG, OUT_PARTICLES)[1:1],
-            )
-            @test_throws "more particles than spins/pols given" GenericQEDProcess(
+            @test_throws InvalidInputError("more particles than spins/pols given") GenericQEDProcess(
                 IN_PARTICLES,
                 OUT_PARTICLES,
                 _random_spin_pols(RNG, IN_PARTICLES),
                 _random_spin_pols(RNG, OUT_PARTICLES)[1:1],
             )
         end
+
         @testset "2 particles, 3 spin/pols" begin
-            @test_throws InvalidInputError GenericQEDProcess(
+            @test_throws InvalidInputError("more spins/pols than particles given") GenericQEDProcess(
                 IN_PARTICLES,
                 OUT_PARTICLES,
                 (_random_spin_pols(RNG, IN_PARTICLES)..., AllPol()),
                 _random_spin_pols(RNG, OUT_PARTICLES),
             )
-            @test_throws "more spins/pols than particles given" GenericQEDProcess(
-                IN_PARTICLES,
-                OUT_PARTICLES,
-                (_random_spin_pols(RNG, IN_PARTICLES)..., AllSpin()),
-                _random_spin_pols(RNG, OUT_PARTICLES),
-            )
-
-            @test_throws InvalidInputError GenericQEDProcess(
+            @test_throws InvalidInputError("more spins/pols than particles given") GenericQEDProcess(
                 IN_PARTICLES,
                 OUT_PARTICLES,
                 _random_spin_pols(RNG, IN_PARTICLES),
                 (_random_spin_pols(RNG, OUT_PARTICLES)..., AllPol()),
-            )
-            @test_throws "more spins/pols than particles given" GenericQEDProcess(
-                IN_PARTICLES,
-                OUT_PARTICLES,
-                _random_spin_pols(RNG, IN_PARTICLES),
-                (_random_spin_pols(RNG, OUT_PARTICLES)..., AllSpin()),
             )
         end
     end

--- a/test/processes/run_process_test.jl
+++ b/test/processes/run_process_test.jl
@@ -1,3 +1,6 @@
+@time @safetestset "generic process" begin
+    include("generic_process/process.jl")
+end
 
 @time @safetestset "general one photon compton" begin
     include("one_photon_compton/process.jl")


### PR DESCRIPTION
Adds a generic QED process, implementing the basic `AbstractProcessDefinition` interface and allowing any combination of particles and spins/pols for them.
The constructor validates that the given spins and polarizations fit to the particles (fermion -> spin, boson -> polarization).

The actual computational functions are as of yet unimplemented and will later be added using the QEDfeynman_diagrams project, once that is public.

Therefore, for now the main use of this type is for testing purposes of other functions.