### PR TITLE
Fix some unintended type promotions

### DIFF
--- a/src/processes/one_photon_compton/perturbative/cross_section.jl
+++ b/src/processes/one_photon_compton/perturbative/cross_section.jl
@@ -25,17 +25,22 @@ function QEDbase._averaging_norm(::Type{T}, proc::Compton) where {T<:Number}
 end
 
 @inline function _all_onshell(psp::PhaseSpacePoint{<:Compton})
+    T = momentum_eltype(psp)
     return @inbounds isapprox(
-            getMass2(momentum(psp, Incoming(), 1)), mass(incoming_particles(psp.proc)[1])^2
+            getMass2(momentum(psp, Incoming(), 1)),
+            mass(T, incoming_particles(psp.proc)[1])^2,
         ) &&
         isapprox(
-            getMass2(momentum(psp, Incoming(), 2)), mass(incoming_particles(psp.proc)[2])^2
+            getMass2(momentum(psp, Incoming(), 2)),
+            mass(T, incoming_particles(psp.proc)[2])^2,
         ) &&
         isapprox(
-            getMass2(momentum(psp, Outgoing(), 1)), mass(outgoing_particles(psp.proc)[1])^2
+            getMass2(momentum(psp, Outgoing(), 1)),
+            mass(T, outgoing_particles(psp.proc)[1])^2,
         ) &&
         isapprox(
-            getMass2(momentum(psp, Outgoing(), 2)), mass(outgoing_particles(psp.proc)[2])^2
+            getMass2(momentum(psp, Outgoing(), 2)),
+            mass(T, outgoing_particles(psp.proc)[2])^2,
         )
 end
 
@@ -106,7 +111,7 @@ function _pert_compton_matrix_element(
         QEDbase._as_svec(out_photon_state),
     )
 
-    matrix_elements = Vector{ComplexF64}()
+    matrix_elements = Vector{Complex{eltype(T)}}()
     sizehint!(matrix_elements, length(base_states_comb))
     for (in_el, in_ph, out_el, out_ph) in base_states_comb
         push!(
@@ -140,8 +145,12 @@ function _pert_compton_matrix_element_single(
     in_ph_slashed = slashed(in_photon_state)
     out_ph_slashed = slashed(out_photon_state)
 
-    prop1 = QEDcore._fermion_propagator(in_photon_mom + in_electron_mom, mass(Electron()))
-    prop2 = QEDcore._fermion_propagator(in_electron_mom - out_photon_mom, mass(Electron()))
+    prop1 = QEDcore._fermion_propagator(
+        in_photon_mom + in_electron_mom, mass(eltype(T), Electron())
+    )
+    prop2 = QEDcore._fermion_propagator(
+        in_electron_mom - out_photon_mom, mass(eltype(T), Electron())
+    )
 
     # TODO: fermion propagator is not yet in QEDbase
     diagram_1 =
@@ -163,9 +172,10 @@ end
 #######
 
 function _pert_compton_ps_fac(
-    in_psl::ComptonSphericalLayout{<:ComptonRestSystem}, in_photon_mom, out_photon_mom
-)
+    in_psl::ComptonSphericalLayout{<:ComptonRestSystem}, in_photon_mom::T, out_photon_mom::T
+) where {T<:AbstractFourMomentum}
     omega = getE(in_photon_mom)
     omega_prime = getE(out_photon_mom)
-    return omega_prime^2 / (16 * pi^2 * omega * mass(Electron()))
+    return omega_prime^2 /
+           (16 * convert(eltype(T), pi)^2 * omega * mass(eltype(T), Electron()))
 end

--- a/src/processes/one_photon_compton/perturbative/kinematics.jl
+++ b/src/processes/one_photon_compton/perturbative/kinematics.jl
@@ -75,7 +75,7 @@ function QEDbase._build_momenta(
     sth = sqrt(1 - cth^2)
     sphi, cphi = sincos(phi)
 
-    Kp = SFourMomentum(
+    Kp = SFourMomentum{T}(
         omega_prime, omega_prime * sth * cphi, omega_prime * sth * sphi, omega_prime * cth
     )
     Pp = Pt - Kp

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,7 +8,7 @@
 
     _base_component_type(array_of_lv::AbstractArray{LV}) where {LV<:AbstractLorentzVector}
 
-Return the type of the components of given Lorentz vectors, which are by themself elements of an
+Return the type of the components of given Lorentz vectors, which are by themselves elements of an
 `AbstractArray`.
 
 # Examples

--- a/test/processes/one_photon_compton/perturbative/kinematics.jl
+++ b/test/processes/one_photon_compton/perturbative/kinematics.jl
@@ -1,4 +1,3 @@
-
 using QEDbase
 using QEDcore
 using QEDprocesses


### PR DESCRIPTION
See https://github.com/QEDjl-project/QEDcore.jl/pull/107 and https://github.com/QEDjl-project/QEDbase.jl/pull/161

A few small changes to fix unintended type promotions by adding concrete types to `mass` and `SFourMomentum` calls.