### PR TITLE
Run fewer GPU tests in CI

### DIFF
--- a/test/gpu/process_interface.jl
+++ b/test/gpu/process_interface.jl
@@ -28,6 +28,11 @@ PROC_DEF_TUPLES = [
 
 RNG = Random.MersenneTwister(573)
 
+if !LARGE_TESTS()
+    @info "Skipping large tests...\nEnable them explicitly with an environment variable LARGE_TESTS=1"
+    PROC_DEF_TUPLES = PROC_DEF_TUPLES[1:5]
+end
+
 @testset "Testing with $GPU_MODULE" for (GPU_MODULE, VECTOR_TYPE) in GPUS
     @testset "Float type $FLOAT_T" for FLOAT_T in GPU_FLOAT_TYPES[GPU_MODULE]
         @testset "$proc $model $psl" for (proc, model, psl) in PROC_DEF_TUPLES

--- a/test/gpu/runtests.jl
+++ b/test/gpu/runtests.jl
@@ -96,6 +96,7 @@ if metal_tests
 end
 
 include("../test_implementation/random_coordinates.jl")
+include("../utils.jl")
 
 # from here on, we cannot use safe test sets or we would unload the GPU libraries again
 include("process_interface.jl")

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,11 @@
+function LARGE_TESTS()
+    # if LARGE_TESTS is set to 0 or 1, use that to decide
+    LT = get(ENV, "LARGE_TESTS", "CI")
+
+    if LT == "CI"
+        # by default, run large tests locally but not in CI
+        return !tryparse(Bool, get(ENV, "CI", "0"))
+    else
+        return tryparse(Bool, LT)
+    end
+end


### PR DESCRIPTION
Adds a testing util function `LARGE_TESTS()` that returns true if larger tests should be run.

If the environment variable `LARGE_TESTS` is explicitly set, it will run them ("1") or skip them ("0"). If it's not set, they will by default be run locally and skipped in the CI, i.e., when `CI` is set.

Currently, this just disables some of the spin/pol combinations tested in the GPU tests, but could be used for more future tests as well. Currently, there is no way to activate the LARGE_TESTS in the CI for a specific run, because we cannot manually set environment variables in the scripts.