### PR TITLE
Fix new GPU test failure

### DIFF
--- a/src/processes/one_photon_compton/perturbative/cross_section.jl
+++ b/src/processes/one_photon_compton/perturbative/cross_section.jl
@@ -147,14 +147,10 @@ function _pert_compton_matrix_element_single(
     )
 
     # TODO: fermion propagator is not yet in QEDbase
-    diagram_1 =
-        out_electron_state *
-        (out_ph_slashed * (prop1 * (in_ph_slashed * in_electron_state)))
-    diagram_2 =
-        out_electron_state *
-        (in_ph_slashed * (prop2 * (out_ph_slashed * in_electron_state)))
+    inner_diagram_1 = (out_ph_slashed * (prop1 * in_ph_slashed))
+    inner_diagram_2 = (in_ph_slashed * (prop2 * out_ph_slashed))
 
-    result = diagram_1 + diagram_2
+    result = out_electron_state * (inner_diagram_1 + inner_diagram_2) * in_electron_state
 
     # TODO: find (preferably unitful) global provider for physical constants
     # elementary charge

--- a/test/gpu/process_interface.jl
+++ b/test/gpu/process_interface.jl
@@ -134,7 +134,15 @@ end
                 gpu = Vector(QEDbase._matrix_element.(gpupsps))
                 gt = QEDbase._matrix_element.(psps)
                 @test eltype(eltype(gpu)) == Complex{FLOAT_T}
-                @test sum(tuple_isapprox.(gpu, gt; rtol = sqrt(eps(FLOAT_T)), atol = eps(FLOAT_T))) == N
+                @test sum(tuple_isapprox.(gpu, gt; rtol = sqrt(eps(FLOAT_T)))) == N
+
+                for i in 1:N
+                    if !tuple_isapprox(gpu[i], gt[i]; rtol = sqrt(eps(FLOAT_T)))
+                        @show gt[i]
+                        @show gpu[i]
+                        @show psps[i]
+                    end
+                end
 
                 gpu = Vector(QEDbase._is_in_phasespace.(gpupsps))
                 gt = QEDbase._is_in_phasespace.(psps)

--- a/test/gpu/process_interface.jl
+++ b/test/gpu/process_interface.jl
@@ -76,103 +76,121 @@ end
                             return QEDbase._averaging_norm(T, proc)
                         end
 
-                        @test all(
+                        @test sum(
                             isapprox.(Vector(_stable_norm.(gpuprocs)), _stable_norm.(procs))
-                        )
+                        ) == N
                     end
                     wrap(FLOAT_T)
                 end
             end
 
             @testset "Public Process Functions" begin
-                @test Vector(incoming_particles.(gpuprocs)) == incoming_particles.(procs)
-                @test Vector(outgoing_particles.(gpuprocs)) == outgoing_particles.(procs)
+                @test sum(Vector(incoming_particles.(gpuprocs)) .== incoming_particles.(procs)) == N
+                @test sum(Vector(outgoing_particles.(gpuprocs)) .== outgoing_particles.(procs)) == N
 
-                @test Vector(particles.(gpuprocs, Incoming())) ==
-                    particles.(procs, Incoming())
-                @test Vector(particles.(gpuprocs, Outgoing())) ==
-                    particles.(procs, Outgoing())
+                @test sum(
+                    Vector(particles.(gpuprocs, Incoming())) .==
+                        particles.(procs, Incoming())
+                ) == N
+                @test sum(
+                    Vector(particles.(gpuprocs, Outgoing())) .==
+                        particles.(procs, Outgoing())
+                ) == N
 
-                @test Vector(number_incoming_particles.(gpuprocs)) ==
-                    number_incoming_particles.(procs)
-                @test Vector(number_outgoing_particles.(gpuprocs)) ==
-                    number_outgoing_particles.(procs)
+                @test sum(
+                    Vector(number_incoming_particles.(gpuprocs)) .==
+                        number_incoming_particles.(procs)
+                ) == N
+                @test sum(
+                    Vector(number_outgoing_particles.(gpuprocs)) .==
+                        number_outgoing_particles.(procs)
+                ) == N
 
-                @test Vector(number_particles.(gpuprocs, Incoming())) ==
-                    number_particles.(procs, Incoming())
-                @test Vector(number_particles.(gpuprocs, Outgoing())) ==
-                    number_particles.(procs, Outgoing())
+                @test sum(
+                    Vector(number_particles.(gpuprocs, Incoming())) .==
+                        number_particles.(procs, Incoming())
+                ) == N
+                @test sum(
+                    Vector(number_particles.(gpuprocs, Outgoing())) .==
+                        number_particles.(procs, Outgoing())
+                ) == N
 
-                @test Vector(QEDbase.in_phase_space_dimension.(gpuprocs, model)) ==
-                    QEDbase.in_phase_space_dimension.(procs, model)
-                @test Vector(QEDbase.out_phase_space_dimension.(gpuprocs, model)) ==
-                    QEDbase.out_phase_space_dimension.(procs, model)
+                @test sum(
+                    Vector(QEDbase.in_phase_space_dimension.(gpuprocs, model)) .==
+                        QEDbase.in_phase_space_dimension.(procs, model)
+                ) == N
+                @test sum(
+                    Vector(QEDbase.out_phase_space_dimension.(gpuprocs, model)) .==
+                        QEDbase.out_phase_space_dimension.(procs, model)
+                ) == N
             end
 
             @testset "Private PSP/Process Interface" begin
-                @test all(
+                @test sum(
                     isapprox.(
                         Vector(QEDbase._incident_flux.(gpupsps)),
                         QEDbase._incident_flux.(psps),
                     ),
-                )
+                ) == N
 
-                @test all(
+                @test sum(
                     tuple_isapprox.(
                         Vector(QEDbase._matrix_element.(gpupsps)),
                         QEDbase._matrix_element.(psps);
                         rtol = sqrt(eps(FLOAT_T)),
                         atol = eps(FLOAT_T),
                     ),
-                )
+                ) == N
 
-                @test Vector(QEDbase._is_in_phasespace.(gpupsps)) ==
-                    QEDbase._is_in_phasespace.(psps)
+                @test sum(
+                    Vector(QEDbase._is_in_phasespace.(gpupsps)) .==
+                        QEDbase._is_in_phasespace.(psps)
+                ) == N
 
-                @test all(
+                @test sum(
                     isapprox.(
                         Vector(QEDbase._phase_space_factor.(gpupsps)),
                         QEDbase._phase_space_factor.(psps),
                     ),
-                )
+                ) == N
 
                 # this currently throws an exception because QuadGK does not work on the GPU
-                @test all(
+                @test sum(
                     isapprox.(
                         Vector(QEDprocesses._total_probability.(gpupsps)),
                         QEDprocesses._total_probability.(psps),
                     ),
-                ) broken = true
+                ) == N broken = true
             end
 
             @testset "Public PSP/Process Interface" begin
-                @test all(
+                @test sum(
                     isapprox.(
                         Vector(differential_probability.(gpupsps)),
                         differential_probability.(psps),
                     ),
-                )
+                ) == N
 
-                @test all(
+                @test sum(
                     isapprox.(
                         Vector(QEDbase._is_in_phasespace.(gpupsps)),
                         QEDbase._is_in_phasespace.(psps),
                     ),
-                )
+                ) == N
 
-                @test all(
+                @test sum(
                     isapprox.(
                         Vector(differential_cross_section.(gpupsps)),
                         differential_cross_section.(psps),
                     ),
-                )
+                ) == N
 
                 # as above, this currently throws an exception because QuadGK does not work on the GPU
-                @test all(
+                @test sum(
                     isapprox.(
                         Vector(total_cross_section.(gpupsps)), total_cross_section.(psps)
                     ),
-                ) broken = true
+                ) == N broken = true
             end
         end
     end

--- a/test/gpu/process_interface.jl
+++ b/test/gpu/process_interface.jl
@@ -35,10 +35,10 @@ end
 
 @testset "Testing with $GPU_MODULE" for (GPU_MODULE, VECTOR_TYPE) in GPUS
     @testset "Float type $FLOAT_T" for FLOAT_T in GPU_FLOAT_TYPES[GPU_MODULE]
-        @testset "$proc $model $psl" for (proc, model, psl) in PROC_DEF_TUPLES
+        @testset "$proc ($(incoming_spin_pols(proc)), $(outgoing_spin_pols(proc)))" for (proc, model, psl) in PROC_DEF_TUPLES
             N = 128
 
-            @info "Testing $proc $model $psl ($FLOAT_T)"
+            @info "Testing $proc ($(incoming_spin_pols(proc)), $(outgoing_spin_pols(proc))) ($FLOAT_T)"
             flush(stdout)
 
             psps = [
@@ -140,7 +140,7 @@ end
                     if !tuple_isapprox(gpu[i], gt[i]; rtol = sqrt(eps(FLOAT_T)))
                         @show gt[i]
                         @show gpu[i]
-                        @show psps[i]
+                        display(psps[i])
                     end
                 end
 

--- a/test/gpu/process_interface.jl
+++ b/test/gpu/process_interface.jl
@@ -41,11 +41,12 @@ end
             @info "Testing $proc ($(incoming_spin_pols(proc)), $(outgoing_spin_pols(proc))) ($FLOAT_T)"
             flush(stdout)
 
-            psps = [
-                PhaseSpacePoint(
-                        proc, model, psl, _rand_coordinates(RNG, proc, model, psl, FLOAT_T)...
-                    ) for _ in 1:N
-            ]
+            coords = [_rand_coordinates(RNG, proc, model, psl, FLOAT_T) for _ in 1:N]
+
+            psps = PhaseSpacePoint.(
+                proc, model, Ref(psl), getindex.(coords, 1), getindex.(coords, 2)
+            )
+
             procs = [proc for _ in 1:N]
 
             gpupsps = VECTOR_TYPE(psps)
@@ -140,6 +141,7 @@ end
                     if !tuple_isapprox(gpu[i], gt[i]; rtol = sqrt(eps(FLOAT_T)))
                         @show gt[i]
                         @show gpu[i]
+                        display(coords[i])
                         display(psps[i])
                     end
                 end

--- a/test/gpu/process_interface.jl
+++ b/test/gpu/process_interface.jl
@@ -126,33 +126,25 @@ end
             end
 
             @testset "Private PSP/Process Interface" begin
-                @test sum(
-                    isapprox.(
-                        Vector(QEDbase._incident_flux.(gpupsps)),
-                        QEDbase._incident_flux.(psps),
-                    ),
-                ) == N
+                gpu = Vector(QEDbase._incident_flux.(gpupsps))
+                gt = QEDbase._incident_flux.(psps)
+                @test eltype(gpu) == FLOAT_T
+                @test sum(isapprox.(gpu, gt)) == N
 
-                @test sum(
-                    tuple_isapprox.(
-                        Vector(QEDbase._matrix_element.(gpupsps)),
-                        QEDbase._matrix_element.(psps);
-                        rtol = sqrt(eps(FLOAT_T)),
-                        atol = eps(FLOAT_T),
-                    ),
-                ) == N
+                gpu = Vector(QEDbase._matrix_element.(gpupsps))
+                gt = QEDbase._matrix_element.(psps)
+                @test eltype(eltype(gpu)) == Complex{FLOAT_T}
+                @test sum(tuple_isapprox.(gpu, gt; rtol = sqrt(eps(FLOAT_T)), atol = eps(FLOAT_T))) == N
 
-                @test sum(
-                    Vector(QEDbase._is_in_phasespace.(gpupsps)) .==
-                        QEDbase._is_in_phasespace.(psps)
-                ) == N
+                gpu = Vector(QEDbase._is_in_phasespace.(gpupsps))
+                gt = QEDbase._is_in_phasespace.(psps)
+                @test eltype(gpu) == Bool
+                @test sum(gpu .== gt) == N
 
-                @test sum(
-                    isapprox.(
-                        Vector(QEDbase._phase_space_factor.(gpupsps)),
-                        QEDbase._phase_space_factor.(psps),
-                    ),
-                ) == N
+                gpu = Vector(QEDbase._phase_space_factor.(gpupsps))
+                gt = QEDbase._phase_space_factor.(psps)
+                @test eltype(gpu) == FLOAT_T
+                @test sum(isapprox.(gpu, gt)) == N
 
                 # this currently throws an exception because QuadGK does not work on the GPU
                 @test sum(
@@ -164,26 +156,20 @@ end
             end
 
             @testset "Public PSP/Process Interface" begin
-                @test sum(
-                    isapprox.(
-                        Vector(differential_probability.(gpupsps)),
-                        differential_probability.(psps),
-                    ),
-                ) == N
+                gpu = Vector(differential_probability.(gpupsps))
+                gt = differential_probability.(psps)
+                @test eltype(gpu) == FLOAT_T
+                @test sum(isapprox.(gpu, gt)) == N
 
-                @test sum(
-                    isapprox.(
-                        Vector(QEDbase._is_in_phasespace.(gpupsps)),
-                        QEDbase._is_in_phasespace.(psps),
-                    ),
-                ) == N
+                gpu = Vector(QEDbase._is_in_phasespace.(gpupsps))
+                gt = QEDbase._is_in_phasespace.(psps)
+                @test eltype(gpu) == Bool
+                @test sum(gpu .== gt) == N
 
-                @test sum(
-                    isapprox.(
-                        Vector(differential_cross_section.(gpupsps)),
-                        differential_cross_section.(psps),
-                    ),
-                ) == N
+                gpu = Vector(differential_cross_section.(gpupsps))
+                gt = differential_cross_section.(psps)
+                @test eltype(gpu) == FLOAT_T
+                @test sum(isapprox.(gpu, gt)) == N
 
                 # as above, this currently throws an exception because QuadGK does not work on the GPU
                 @test sum(

--- a/test/test_implementation/random_coordinates.jl
+++ b/test/test_implementation/random_coordinates.jl
@@ -7,7 +7,8 @@ Return a tuple of tuples of incoming and outgoing coordinates for a given proces
 function _rand_coordinates(
         rng::AbstractRNG, ::PROCESS, ::MODEL, ::PSL, FLOAT_T = Float64
     ) where {PROCESS <: Compton, MODEL <: PerturbativeQED, PSL <: AbstractPhaseSpaceLayout}
-    return ((rand(rng, FLOAT_T),), (rand(rng, FLOAT_T), rand(rng, FLOAT_T)))
+    # TODO: this adds a small bit to the incoming energy to prevent precision problems that appear when it's close to 0
+    return ((FLOAT_T(0.95) * rand(rng, FLOAT_T) + FLOAT_T(0.05),), (rand(rng, FLOAT_T), rand(rng, FLOAT_T)))
 end
 
 tuple_iaspprox(::Tuple{}, ::Tuple{Vararg}; atol = 0.0, rtol = eps()) = false


### PR DESCRIPTION
My best guess is that one of the random momenta hits an unstable spot yielding bad precision, since it only happens so rarely. Maybe we'll have to add a `singularity_proximity` measure or similar to check beforehand if it's likely that a psp will be unstable.