### PR TITLE
Support CI_QED_ prefixed environment varibles to select platform to test (e.g. CPU, CUDA ...)

### DIFF
--- a/test/gpu/runtests.jl
+++ b/test/gpu/runtests.jl
@@ -4,11 +4,13 @@ functional, and execute the unit tests then. Additionally, if an environment var
 ("TEST_<GPU> = 1"), the tests will fail if the library is not functional.
 """
 
+include("../utils.jl")
+
 GPUS = Vector{Tuple{Module, Type}}()
 GPU_FLOAT_TYPES = Dict{Module, Vector{Type}}()
 
 # check if we test with AMDGPU
-amdgpu_tests = tryparse(Bool, get(ENV, "TEST_AMDGPU", "0"))
+amdgpu_tests = _is_test_platform_active(["CI_QED_TEST_AMDGPU", "TEST_AMDGPU"], false)
 if amdgpu_tests
     try
         using Pkg
@@ -31,7 +33,7 @@ if amdgpu_tests
 end
 
 # check if we test with CUDA
-cuda_tests = tryparse(Bool, get(ENV, "TEST_CUDA", "0"))
+cuda_tests = _is_test_platform_active(["CI_QED_TEST_CUDA", "TEST_CUDA"], false)
 if cuda_tests
     try
         using Pkg
@@ -51,7 +53,7 @@ if cuda_tests
 end
 
 # check if we test with oneAPI
-oneapi_tests = tryparse(Bool, get(ENV, "TEST_ONEAPI", "0"))
+oneapi_tests = _is_test_platform_active(["CI_QED_TEST_ONEAPI", "TEST_ONEAPI"], false)
 if oneapi_tests
     try
         using Pkg
@@ -76,7 +78,7 @@ if oneapi_tests
 end
 
 # check if we test with Metal
-metal_tests = tryparse(Bool, get(ENV, "TEST_METAL", "0"))
+metal_tests = _is_test_platform_active(["CI_QED_TEST_METAL", "TEST_METAL"], false)
 if metal_tests
     try
         using Pkg

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,10 @@
 using Test
 using SafeTestsets
 
+include("utils.jl")
+
 # check if we run CPU tests (yes by default)
-cpu_tests = tryparse(Bool, get(ENV, "TEST_CPU", "1"))
+cpu_tests = _is_test_platform_active(["CI_QED_TEST_CPU", "TEST_CPU"], true)
 
 if cpu_tests
     # scattering processes

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -9,3 +9,24 @@ function LARGE_TESTS()
         return tryparse(Bool, LT)
     end
 end
+
+"""
+    _is_test_platform_active(env_vars::AbstractVector{String}, default::Bool)::Bool
+
+# Args
+- `env_vars::AbstractVector{String}`: List of the names of environment variables. The value of the
+    first defined variable in the list is parsed and returned.
+- `default::Bool`: If none of the variables named in `env_vars` are defined, this value is returned.
+
+# Return
+
+Return if platform is active or not.
+"""
+function _is_test_platform_active(env_vars::AbstractVector{String}, default::Bool)::Bool
+    for env_var in env_vars
+        if haskey(ENV, env_var)
+            return tryparse(Bool, ENV[env_var])
+        end
+    end
+    return default
+end


### PR DESCRIPTION
The environment variables TEST_CPU, TEST_CUDA, TEST_AMDGPU, TEST_ONEAPI and TEST_METAL are still working for easy usage by developers. Additional all variables are allowed with the prefix CI_QED_ to be consistent with the CI variable naming scheme.