### PR TITLE
Fix dcs metal

### DIFF
--- a/src/processes/one_photon_compton/perturbative/cross_section.jl
+++ b/src/processes/one_photon_compton/perturbative/cross_section.jl
@@ -7,7 +7,7 @@ function QEDbase._incident_flux(in_psp::InPhaseSpacePoint{<:Compton, Perturbativ
     return momentum(in_psp, Incoming(), 1) * momentum(in_psp, Incoming(), 2)
 end
 
-function QEDbase._matrix_element(psp::PhaseSpacePoint{<:Compton, PerturbativeQED})
+@inline function QEDbase._matrix_element(psp::PhaseSpacePoint{<:Compton, PerturbativeQED})
     in_ps = momenta(psp, Incoming())
     out_ps = momenta(psp, Outgoing())
     return _pert_compton_matrix_element(psp.proc, in_ps, out_ps)
@@ -82,7 +82,7 @@ end
     )
 end
 
-function _pert_compton_matrix_element(
+@inline function _pert_compton_matrix_element(
         in_electron_mom::T,
         in_electron_state,
         in_photon_mom::T,
@@ -99,7 +99,12 @@ function _pert_compton_matrix_element(
         QEDbase._as_svec(out_photon_state),
     )
 
-    matrix_elements::NTuple{length(base_states_comb), Complex{eltype(T)}} = (
+    #state_tuple = collect(base_states_comb)
+
+
+    # TODO: replace this with broadcast over spins (or look what Anton does in
+    # ComputableDAGs)
+    @inline matrix_elements::SVector{length(base_states_comb), Complex{eltype(T)}} = (
         (
             _pert_compton_matrix_element_single(
                     in_electron_mom,
@@ -115,6 +120,26 @@ function _pert_compton_matrix_element(
     )
 
     return matrix_elements
+end
+
+@inline function _pert_compton_matrix_element_single(
+        in_electron_mom::T,
+        in_photon_mom::T,
+        out_electron_mom::T,
+        out_photon_mom::T,
+        state_tuple::Tuple
+    ) where {T <: AbstractFourMomentum}
+    in_electron_state, in_photon_state, out_electron_state, out_photon_state = state_tuple
+    return _pert_compton_matrix_element_single(
+        in_electron_mom,
+        in_electron_state,
+        in_photon_mom,
+        in_photon_state,
+        out_electron_mom,
+        out_electron_state,
+        out_photon_mom,
+        out_photon_state
+    )
 end
 
 function _pert_compton_matrix_element_single(

--- a/test/test_implementation/random_coordinates.jl
+++ b/test/test_implementation/random_coordinates.jl
@@ -11,8 +11,8 @@ function _rand_coordinates(
     return ((FLOAT_T(0.95) * rand(rng, FLOAT_T) + FLOAT_T(0.05),), (rand(rng, FLOAT_T), rand(rng, FLOAT_T)))
 end
 
-tuple_iaspprox(::Tuple{}, ::Tuple{Vararg}; atol = 0.0, rtol = eps()) = false
-tuple_iaspprox(::Tuple{Vararg}, ::Tuple{}; atol = 0.0, rtol = eps()) = false
+tuple_isapprox(::Tuple{}, ::Tuple{Vararg}; atol = 0.0, rtol = eps()) = false
+tuple_isapprox(::Tuple{Vararg}, ::Tuple{}; atol = 0.0, rtol = eps()) = false
 tuple_isapprox(::Tuple{}, ::Tuple{}; atol = 0.0, rtol = eps()) = true
 function tuple_isapprox(
         a::Tuple{<:Number, Vararg}, b::Tuple{<:Number, Vararg}; atol = 0.0, rtol = eps()

--- a/test/test_implementation/random_coordinates.jl
+++ b/test/test_implementation/random_coordinates.jl
@@ -1,5 +1,6 @@
 using QEDcore, QEDprocesses
 using Random
+using StaticArrays
 
 """
 Return a tuple of tuples of incoming and outgoing coordinates for a given process, model and ps_def that make up a physical phase space point.
@@ -11,6 +12,7 @@ function _rand_coordinates(
     return ((FLOAT_T(0.95) * rand(rng, FLOAT_T) + FLOAT_T(0.05),), (rand(rng, FLOAT_T), rand(rng, FLOAT_T)))
 end
 
+tuple_isapprox(v1::SVector, v2::SVector; kwargs...) = tuple_isapprox(Tuple(v1), Tuple(v2); kwargs...)
 tuple_isapprox(::Tuple{}, ::Tuple{Vararg}; atol = 0.0, rtol = eps()) = false
 tuple_isapprox(::Tuple{Vararg}, ::Tuple{}; atol = 0.0, rtol = eps()) = false
 tuple_isapprox(::Tuple{}, ::Tuple{}; atol = 0.0, rtol = eps()) = true


### PR DESCRIPTION
Calculating differential cross sections failed when broadcasting over an `MtlVector` of phase space points. The construction of the tuple of matrix elements for each spin-pol combination causes this. It seems like Julia does not unroll it properly, if the number of elements is larger than 10 (which is the case for the fully unpolarized Compton). Therefore, a replacement of the tuple construction by a version using `StaticVector`, which is fully unrolled, fixes the problem. 

consider for merging after #133 