### PR TITLE
KernelAbstractions kernels

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-ComputableDAGs = "0.4.0"
+ComputableDAGs = "0.5.0"
 KernelAbstractions = "0.9.38"
 Memoization = "0.2.2"
 QEDFeynmanDiagrams = "0.1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,11 @@
 name = "QEDprocesses"
 uuid = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
-authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
 version = "0.5.1"
+authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
 
 [deps]
+ComputableDAGs = "62933717-1c9d-4a3f-b06f-7ab7f17ca32d"
+KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 Memoization = "6fafb56a-5788-4b4e-91ca-c0cea6611c73"
 QEDFeynmanDiagrams = "3232ad24-8ec1-4588-843e-e2ed2eae1ff3"
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
@@ -14,6 +16,7 @@ RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+KernelAbstractions = "0.9.38"
 Memoization = "0.2.2"
 QEDFeynmanDiagrams = "0.1"
 QEDbase = "0.5.0"

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ RuntimeGeneratedFunctions = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+ComputableDAGs = "0.4.0"
 KernelAbstractions = "0.9.38"
 Memoization = "0.2.2"
 QEDFeynmanDiagrams = "0.1"

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -16,6 +16,7 @@ using QEDbase
 using QEDcore
 using StaticArrays
 using QuadGK
+using Memoization
 using KernelAbstractions
 using ComputableDAGs
 ComputableDAGs.init(@__MODULE__)

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -16,6 +16,7 @@ using QEDbase
 using QEDcore
 using StaticArrays
 using QuadGK
+using KernelAbstractions
 
 include("utils.jl")
 

--- a/src/QEDprocesses.jl
+++ b/src/QEDprocesses.jl
@@ -17,6 +17,9 @@ using QEDcore
 using StaticArrays
 using QuadGK
 using KernelAbstractions
+using ComputableDAGs
+ComputableDAGs.init(@__MODULE__)
+ComputableDAGs.init_kernel(@__MODULE__)
 
 include("utils.jl")
 
@@ -28,6 +31,7 @@ include("processes/utils.jl")
 include("processes/generic_process/utility.jl")
 include("processes/generic_process/process.jl")
 include("processes/generic_process/perturbative/cross_section.jl")
+include("processes/generic_process/gen_func.jl")
 
 # one photon compton
 include("processes/one_photon_compton/process.jl")

--- a/src/processes/generic_process/gen_func.jl
+++ b/src/processes/generic_process/gen_func.jl
@@ -1,0 +1,21 @@
+using Memoization
+
+@memoize function _generic_proc_graph(proc::PROC) where {PROC <: ScatteringProcess}
+    g = graph(proc)
+    optimize_to_fixpoint!(ReductionOptimizer(), g)
+    return g
+end
+
+@memoize function _mat_el_func(proc::PROC, ::Type{PSP}) where {
+        PROC <: ScatteringProcess, PSP <: PhaseSpacePoint{PROC, PerturbativeQED},
+    }
+    g = _generic_proc_graph(proc)
+    return compute_function(g, proc, cpu_st(), @__MODULE__)
+end
+
+@memoize function _mat_el_kernel(proc::PROC, ::Type{PSP}) where {
+        PROC <: ScatteringProcess, PSP <: PhaseSpacePoint{PROC, PerturbativeQED},
+    }
+    g = _generic_proc_graph(proc)
+    return kernel(g, proc, @__MODULE__)
+end

--- a/src/processes/generic_process/gen_func.jl
+++ b/src/processes/generic_process/gen_func.jl
@@ -1,5 +1,3 @@
-using Memoization
-
 """
     _generic_proc_graph(proc::ScatteringProcess, target::Symbol)
 
@@ -15,9 +13,9 @@ Returns the generated DAG for the given [`ScatteringProcess`](@ref) and the spec
 end
 
 """
-    _mat_el_sq_sum_func(proc::ScatteringProcess, target::Symbol)
+    _mat_el_sq_sum_func(proc::ScatteringProcess, ::Type{PSP})
 
-Returns the generated compute function ready to be called on a `PhaseSpacePoint`, returning the square sum of matrix elements.
+Returns the generated compute function ready to be called on a `PhaseSpacePoint::PSP`, returning the square sum of matrix elements.
 
 !!! note
     This function is memoized so it will cache the result for a unique set of arguments and not reevaluate.
@@ -30,10 +28,10 @@ Returns the generated compute function ready to be called on a `PhaseSpacePoint`
 end
 
 """
-    _diff_cs_kernel(proc::ScatteringProcess, target::Symbol)
+    _diff_cs_kernel(proc::ScatteringProcess, ::Type{PSP})
 
 Returns a generated KernelAbstractions.jl kernel ready to be called to compute differential cross sections on any of KernelAbstractions.jl's backends.
-The function signature is `diff_cs(out::AbstractVector{FLOAT_T}, in::AbstractVector{PhaseSpacePoint{...}})`, where the phase space points' underlying float type must be convertible to `FLOAT_T`.
+The function signature is `diff_cs(out::AbstractVector{FLOAT_T}, in::AbstractVector{PhaseSpacePoint{...}})`, where the phase space point must be of type `PSP` and its underlying float type must be convertible to `FLOAT_T`.
 
 !!! note
     This function is memoized so it will cache the result for a unique set of arguments and not reevaluate.
@@ -48,10 +46,10 @@ See also: [`_diff_prob_kernel`](@ref)
 end
 
 """
-    _diff_prob_kernel(proc::ScatteringProcess, target::Symbol)
+    _diff_prob_kernel(proc::ScatteringProcess, ::Type{PSP})
 
 Returns a generated KernelAbstractions.jl kernel ready to be called to compute differential probability on any of KernelAbstractions.jl's backends.
-The function signature is `diff_cs(out::AbstractVector{FLOAT_T}, in::AbstractVector{PhaseSpacePoint{...}})`, where the phase space points' underlying float type must be convertible to `FLOAT_T`.
+The function signature is `diff_cs(out::AbstractVector{FLOAT_T}, in::AbstractVector{PhaseSpacePoint{...}})`, where the phase space point must be of type `PSP` and its underlying float type must be convertible to `FLOAT_T`.
 
 !!! note
     This function is memoized so it will cache the result for a unique set of arguments and not reevaluate.

--- a/src/processes/generic_process/gen_func.jl
+++ b/src/processes/generic_process/gen_func.jl
@@ -1,25 +1,45 @@
 using Memoization
 
+"""
+    _generic_proc_graph(proc::ScatteringProcess, target::Symbol)
+
+Returns the generated DAG for the given [`ScatteringProcess`](@ref) and the specific target, one of `:mat_el_sqsum`, `:diff_prob`, `:diff_cs`.
+
+!!! note
+    This function is memoized so it will cache the result for a unique set of arguments and not reevaluate.
+"""
 @memoize function _generic_proc_graph(proc::PROC, target::Symbol) where {PROC <: ScatteringProcess}
     g = graph(proc; target = target)
     optimize_to_fixpoint!(ReductionOptimizer(), g)
     return g
 end
 
-@memoize function _mat_el_func(proc::PROC, ::Type{PSP}) where {
+"""
+    _mat_el_sq_sum_func(proc::ScatteringProcess, target::Symbol)
+
+Returns the generated compute function ready to be called on a [`PhaseSpacePoint`](@extref QEDcore.PhaseSpacePoint), returning the square sum of matrix elements.
+
+!!! note
+    This function is memoized so it will cache the result for a unique set of arguments and not reevaluate.
+"""
+@memoize function _mat_el_sq_sum_func(proc::PROC, ::Type{PSP}) where {
         PROC <: ScatteringProcess, PSP <: PhaseSpacePoint{PROC, PerturbativeQED},
     }
     g = _generic_proc_graph(proc, :mat_el_sqsum)
     return compute_function(g, proc, cpu_st(), @__MODULE__)
 end
 
-@memoize function _mat_el_kernel(proc::PROC, ::Type{PSP}) where {
-        PROC <: ScatteringProcess, PSP <: PhaseSpacePoint{PROC, PerturbativeQED},
-    }
-    g = _generic_proc_graph(proc, :mat_el_sqsum)
-    return kernel(g, proc, @__MODULE__)
-end
+"""
+    _diff_cs_kernel(proc::ScatteringProcess, target::Symbol)
 
+Returns a generated KernelAbstractions.jl kernel ready to be called to compute differential cross sections on any of KernelAbstractions.jl's backends.
+The function signature is `diff_cs(out::AbstractVector{FLOAT_T}, in::AbstractVector{PhaseSpacePoint{...}})`, where the phase space points' underlying float type must be convertible to `FLOAT_T`.
+
+!!! note
+    This function is memoized so it will cache the result for a unique set of arguments and not reevaluate.
+
+See also: [`_diff_prob_kernel`](@ref)
+"""
 @memoize function _diff_cs_kernel(proc::PROC, ::Type{PSP}) where {
         PROC <: ScatteringProcess, PSP <: PhaseSpacePoint{PROC, PerturbativeQED},
     }
@@ -27,6 +47,17 @@ end
     return kernel(g, proc, @__MODULE__)
 end
 
+"""
+    _diff_prob_kernel(proc::ScatteringProcess, target::Symbol)
+
+Returns a generated KernelAbstractions.jl kernel ready to be called to compute differential probability on any of KernelAbstractions.jl's backends.
+The function signature is `diff_cs(out::AbstractVector{FLOAT_T}, in::AbstractVector{PhaseSpacePoint{...}})`, where the phase space points' underlying float type must be convertible to `FLOAT_T`.
+
+!!! note
+    This function is memoized so it will cache the result for a unique set of arguments and not reevaluate.
+
+See also: [`_diff_cs_kernel`](@ref)
+"""
 @memoize function _diff_prob_kernel(proc::PROC, ::Type{PSP}) where {
         PROC <: ScatteringProcess, PSP <: PhaseSpacePoint{PROC, PerturbativeQED},
     }

--- a/src/processes/generic_process/gen_func.jl
+++ b/src/processes/generic_process/gen_func.jl
@@ -17,7 +17,7 @@ end
 """
     _mat_el_sq_sum_func(proc::ScatteringProcess, target::Symbol)
 
-Returns the generated compute function ready to be called on a [`PhaseSpacePoint`](@extref QEDcore.PhaseSpacePoint), returning the square sum of matrix elements.
+Returns the generated compute function ready to be called on a `PhaseSpacePoint`, returning the square sum of matrix elements.
 
 !!! note
     This function is memoized so it will cache the result for a unique set of arguments and not reevaluate.

--- a/src/processes/generic_process/gen_func.jl
+++ b/src/processes/generic_process/gen_func.jl
@@ -1,7 +1,7 @@
 using Memoization
 
-@memoize function _generic_proc_graph(proc::PROC) where {PROC <: ScatteringProcess}
-    g = graph(proc)
+@memoize function _generic_proc_graph(proc::PROC, target::Symbol) where {PROC <: ScatteringProcess}
+    g = graph(proc; target = target)
     optimize_to_fixpoint!(ReductionOptimizer(), g)
     return g
 end
@@ -9,13 +9,27 @@ end
 @memoize function _mat_el_func(proc::PROC, ::Type{PSP}) where {
         PROC <: ScatteringProcess, PSP <: PhaseSpacePoint{PROC, PerturbativeQED},
     }
-    g = _generic_proc_graph(proc)
+    g = _generic_proc_graph(proc, :mat_el_sqsum)
     return compute_function(g, proc, cpu_st(), @__MODULE__)
 end
 
 @memoize function _mat_el_kernel(proc::PROC, ::Type{PSP}) where {
         PROC <: ScatteringProcess, PSP <: PhaseSpacePoint{PROC, PerturbativeQED},
     }
-    g = _generic_proc_graph(proc)
+    g = _generic_proc_graph(proc, :mat_el_sqsum)
+    return kernel(g, proc, @__MODULE__)
+end
+
+@memoize function _diff_cs_kernel(proc::PROC, ::Type{PSP}) where {
+        PROC <: ScatteringProcess, PSP <: PhaseSpacePoint{PROC, PerturbativeQED},
+    }
+    g = _generic_proc_graph(proc, :diff_cs)
+    return kernel(g, proc, @__MODULE__)
+end
+
+@memoize function _diff_prob_kernel(proc::PROC, ::Type{PSP}) where {
+        PROC <: ScatteringProcess, PSP <: PhaseSpacePoint{PROC, PerturbativeQED},
+    }
+    g = _generic_proc_graph(proc, :diff_prob)
     return kernel(g, proc, @__MODULE__)
 end

--- a/src/processes/generic_process/perturbative/cross_section.jl
+++ b/src/processes/generic_process/perturbative/cross_section.jl
@@ -72,7 +72,7 @@ function QEDbase.unsafe_differential_cross_section!(dest::AbstractVector, in_psp
         PSP <: AbstractPhaseSpacePoint{PROC, MODEL},
     }
     @assert length(in_psps) == length(dest)
-    @show k = _diff_cs_kernel(_scattering_proc_from_type(PROC), PSP)
+    k = _diff_cs_kernel(_scattering_proc_from_type(PROC), PSP)
     return k(get_backend(dest))(dest, in_psps; ndrange = length(dest))
 end
 
@@ -82,6 +82,6 @@ function QEDbase.unsafe_differential_probability!(dest::AbstractVector, in_psps:
         PSP <: AbstractPhaseSpacePoint{PROC, MODEL},
     }
     @assert length(in_psps) == length(dest)
-    @show k = _diff_prob_kernel(_scattering_proc_from_type(PROC), PSP)
+    k = _diff_prob_kernel(_scattering_proc_from_type(PROC), PSP)
     return k(get_backend(dest))(dest, in_psps; ndrange = length(dest))
 end

--- a/src/processes/generic_process/perturbative/cross_section.jl
+++ b/src/processes/generic_process/perturbative/cross_section.jl
@@ -66,8 +66,22 @@ function QEDbase._incident_flux(psp::InPhaseSpacePoint{PROC, PerturbativeQED}) w
     return QEDcore.sq_diff_sqrt(p1_mom * p2_mom, p1_mass * p2_mass)
 end
 
-function QEDbase._matrix_element_square_sum(in_psps::AbstractVector{PSP}, out::AbstractVector) where {PSP <: AbstractPhaseSpacePoint}
-    @assert length(in_psps) == length(out)
+function QEDbase.unsafe_differential_cross_section!(dest::AbstractVector, in_psps::AbstractVector{PSP}) where {
+        MODEL <: PerturbativeQED,
+        PROC <: ScatteringProcess,
+        PSP <: AbstractPhaseSpacePoint{PROC, MODEL},
+    }
+    @assert length(in_psps) == length(dest)
+    @show k = _diff_cs_kernel(_scattering_proc_from_type(PROC), PSP)
+    return k(get_backend(dest))(dest, in_psps; ndrange = length(dest))
+end
 
-    return _mat_el_kernel()
+function QEDbase.unsafe_differential_probability!(dest::AbstractVector, in_psps::AbstractVector{PSP}) where {
+        MODEL <: PerturbativeQED,
+        PROC <: ScatteringProcess,
+        PSP <: AbstractPhaseSpacePoint{PROC, MODEL},
+    }
+    @assert length(in_psps) == length(dest)
+    @show k = _diff_prob_kernel(_scattering_proc_from_type(PROC), PSP)
+    return k(get_backend(dest))(dest, in_psps; ndrange = length(dest))
 end

--- a/src/processes/generic_process/perturbative/cross_section.jl
+++ b/src/processes/generic_process/perturbative/cross_section.jl
@@ -1,5 +1,3 @@
-using Memoization
-
 @inline function _all_onshell(psp::PhaseSpacePoint{<:ScatteringProcess})
     return _all_onshell(particles(psp, Incoming())) && _all_onshell(particles(psp, Outgoing()))
 end
@@ -18,15 +16,6 @@ function _scattering_proc_from_type(::Type{ScatteringProcess{IN_T, OUT_T, IN_SP,
         _ctor(IN_SP),
         _ctor(OUT_SP),
     )
-end
-
-@memoize function _mat_el_func(proc::PROC, ::Type{PSP}) where {
-        PROC <: ScatteringProcess, PSP <: PhaseSpacePoint{PROC, PerturbativeQED},
-    }
-    g = graph(proc)
-    # TODO: there seems to be a bug in 1.12 with ComputableDAGs.jl. Enable this again once it's fixed
-    #optimize_to_fixpoint!(ReductionOptimizer(), g)
-    return get_compute_function(g, proc, cpu_st(), @__MODULE__; closures_size = 1000, concrete_input_type = PSP)
 end
 
 function QEDbase._matrix_element(psp::PhaseSpacePoint{PROC, PerturbativeQED}) where {PROC <: ScatteringProcess}
@@ -75,4 +64,10 @@ function QEDbase._incident_flux(psp::InPhaseSpacePoint{PROC, PerturbativeQED}) w
     p2_mass = mass(EL_TYPE, incoming_particles(proc)[2])
 
     return QEDcore.sq_diff_sqrt(p1_mom * p2_mom, p1_mass * p2_mass)
+end
+
+function QEDbase._matrix_element_square_sum(in_psps::AbstractVector{PSP}, out::AbstractVector) where {PSP <: AbstractPhaseSpacePoint}
+    @assert length(in_psps) == length(out)
+
+    return _mat_el_kernel()
 end

--- a/src/processes/generic_process/perturbative/cross_section.jl
+++ b/src/processes/generic_process/perturbative/cross_section.jl
@@ -19,12 +19,12 @@ function _scattering_proc_from_type(::Type{ScatteringProcess{IN_T, OUT_T, IN_SP,
 end
 
 function QEDbase._matrix_element(psp::PhaseSpacePoint{PROC, PerturbativeQED}) where {PROC <: ScatteringProcess}
-    mat_el_func = _mat_el_func(process(psp), typeof(psp))
+    mat_el_func = _mat_el_sq_sum_func(process(psp), typeof(psp))
     return sqrt(mat_el_func(psp))
 end
 
 function QEDbase._matrix_element_square_sum(psp::PhaseSpacePoint{PROC, PerturbativeQED}) where {PROC <: ScatteringProcess}
-    mat_el_func = _mat_el_func(process(psp), typeof(psp))
+    mat_el_func = _mat_el_sq_sum_func(process(psp), typeof(psp))
     return mat_el_func(psp)
 end
 

--- a/test/gpu/generic_process.jl
+++ b/test/gpu/generic_process.jl
@@ -60,10 +60,10 @@ RNG = Random.MersenneTwister(573)
                 @test eltype(eltype(eltype(in_moms))) == FLOAT_T
                 @test eltype(eltype(eltype(out_moms))) == FLOAT_T
 
-                @test getindex.(in_moms_gpu, Ref(1)) == getindex.(in_moms, Ref(1))
-                @test getindex.(in_moms_gpu, Ref(2)) == getindex.(in_moms, Ref(2))
-                @test getindex.(out_moms_gpu, Ref(1)) == getindex.(out_moms, Ref(1))
-                @test getindex.(out_moms_gpu, Ref(2)) == getindex.(out_moms, Ref(2))
+                @test getindex.(in_moms_gpu, 1) == getindex.(in_moms, 1)
+                @test getindex.(in_moms_gpu, 2) == getindex.(in_moms, 2)
+                @test getindex.(out_moms_gpu, 1) == getindex.(out_moms, 1)
+                @test getindex.(out_moms_gpu, 2) == getindex.(out_moms, 2)
             end
 
             @testset "Private Process Functions" begin

--- a/test/gpu/generic_process.jl
+++ b/test/gpu/generic_process.jl
@@ -15,15 +15,13 @@ DEF_POLS = (PolX(), PolY())
 DEF_SPINS = (SpinUp(), SpinDown())
 
 const MODEL = PerturbativeQED()
-const IN_PSL_COMPTON = ComptonRestSystem(Energy(2))
-const OUT_PSL_COMPTON = ComptonSphericalLayout(IN_PSL_COMPTON)
+
+const IN_PSL_GENERIC = TwoBodyRestSystem()
+const OUT_PSL_GENERIC = FlatPhaseSpaceLayout(IN_PSL_GENERIC)
 
 PROC_DEF_TUPLES = [
-    (Compton(), MODEL, OUT_PSL_COMPTON),
-    [
-        (Compton(s1, p1, s2, p2), MODEL, OUT_PSL_COMPTON) for
-            (s1, p1, s2, p2) in Iterators.product(DEF_SPINS, DEF_POLS, DEF_SPINS, DEF_POLS)
-    ]...,
+    (ScatteringProcess((Electron(), Photon()), (Electron(), Photon())), MODEL, OUT_PSL_GENERIC),
+    (ScatteringProcess((Electron(), Positron()), (Electron(), Positron())), MODEL, OUT_PSL_GENERIC),
 ]
 
 RNG = Random.MersenneTwister(573)
@@ -132,21 +130,6 @@ end
                 @test eltype(gpu) == FLOAT_T
                 @test sum(isapprox.(gpu, gt)) == N
 
-                gpu = Vector(QEDbase._matrix_element_square_sum.(gpupsps))
-                gt = QEDbase._matrix_element_square_sum.(psps)
-                @test eltype(eltype(gpu)) == FLOAT_T
-                @test sum(isapprox.(gpu, gt; rtol = sqrt(eps(FLOAT_T)))) == N
-
-                for i in 1:N
-                    if !isapprox(gpu[i], gt[i]; rtol = sqrt(eps(FLOAT_T)))
-                        @show gt[i]
-                        @show gpu[i]
-                        display(coords[i])
-                        display(psps[i])
-                        flush!(stdout)
-                    end
-                end
-
                 gpu = Vector(QEDbase._is_in_phasespace.(gpupsps))
                 gt = QEDbase._is_in_phasespace.(psps)
                 @test eltype(gpu) == Bool
@@ -156,60 +139,34 @@ end
                 gt = QEDbase._phase_space_factor.(psps)
                 @test eltype(gpu) == FLOAT_T
                 @test sum(isapprox.(gpu, gt)) == N
-
-                # this currently throws an exception because QuadGK does not work on the GPU
-                @test sum(
-                    isapprox.(
-                        Vector(QEDprocesses._total_probability.(gpupsps)),
-                        QEDprocesses._total_probability.(psps),
-                    ),
-                ) == N broken = true
             end
 
-            @testset "Public PSP/Process Interface" begin
-                gpu = Vector(differential_probability.(gpupsps))
+            @testset "KernelAbstractions Probability" begin
+                dest = similar(gpupsps, FLOAT_T)
+                gt = unsafe_differential_probability.(psps)
+                unsafe_differential_probability!(dest, gpupsps)
+                @test sum(isapprox.(Vector(dest), gt)) == N
+
+                #=
+                fill!(dest, zero(FLOAT_T))
                 gt = differential_probability.(psps)
-                @test eltype(gpu) == FLOAT_T
-                @test sum(isapprox.(gpu, gt)) == N
-
-                gpu = Vector(QEDbase._is_in_phasespace.(gpupsps))
-                gt = QEDbase._is_in_phasespace.(psps)
-                @test eltype(gpu) == Bool
-                @test sum(gpu .== gt) == N
-
-                gpu = Vector(differential_cross_section.(gpupsps))
-                gt = differential_cross_section.(psps)
-                @test eltype(gpu) == FLOAT_T
-                @test sum(isapprox.(gpu, gt)) == N
-
-                # as above, this currently throws an exception because QuadGK does not work on the GPU
-                @test sum(
-                    isapprox.(
-                        Vector(total_cross_section.(gpupsps)), total_cross_section.(psps)
-                    ),
-                ) == N broken = true
+                differential_probability!(dest, gpupsps)
+                @test sum(isapprox.(Vector(dest), gt)) == N
+                =#
             end
 
-            @testset "KernelAbstractions Kernel Interface" begin
+            @testset "KernelAbstractions Cross Section" begin
                 dest = similar(gpupsps, FLOAT_T)
                 gt = unsafe_differential_cross_section.(psps)
                 unsafe_differential_cross_section!(dest, gpupsps)
                 @test sum(isapprox.(Vector(dest), gt)) == N
 
+                #=
                 fill!(dest, zero(FLOAT_T))
                 gt = differential_cross_section.(psps)
                 differential_cross_section!(dest, gpupsps)
                 @test sum(isapprox.(Vector(dest), gt)) == N
-
-                fill!(dest, zero(FLOAT_T))
-                gt = unsafe_differential_probability.(psps)
-                unsafe_differential_probability!(dest, gpupsps)
-                @test sum(isapprox.(Vector(dest), gt)) == N
-
-                fill!(dest, zero(FLOAT_T))
-                gt = differential_probability.(psps)
-                differential_probability!(dest, gpupsps)
-                @test sum(isapprox.(Vector(dest), gt)) == N
+                =#
             end
         end
     end

--- a/test/gpu/generic_process.jl
+++ b/test/gpu/generic_process.jl
@@ -30,11 +30,6 @@ PROC_DEF_TUPLES = [
 
 RNG = Random.MersenneTwister(573)
 
-if !LARGE_TESTS()
-    @info "Skipping large tests...\nEnable them explicitly with an environment variable LARGE_TESTS=1"
-    PROC_DEF_TUPLES = PROC_DEF_TUPLES[1:5]
-end
-
 @testset "Testing with $GPU_MODULE" for (GPU_MODULE, VECTOR_TYPE) in GPUS
     @testset "Float type $FLOAT_T" for FLOAT_T in GPU_FLOAT_TYPES[GPU_MODULE]
         @testset "$proc ($(incoming_spin_pols(proc)), $(outgoing_spin_pols(proc)))" for (proc, model, psl) in PROC_DEF_TUPLES

--- a/test/gpu/generic_process.jl
+++ b/test/gpu/generic_process.jl
@@ -9,7 +9,6 @@ using QEDbase
 using QEDcore
 
 using Random
-using SafeTestsets
 
 DEF_POLS = (PolX(), PolY())
 DEF_SPINS = (SpinUp(), SpinDown())
@@ -22,6 +21,11 @@ const OUT_PSL_GENERIC = FlatPhaseSpaceLayout(IN_PSL_GENERIC)
 PROC_DEF_TUPLES = [
     (ScatteringProcess((Electron(), Photon()), (Electron(), Photon())), MODEL, OUT_PSL_GENERIC),
     (ScatteringProcess((Electron(), Positron()), (Electron(), Positron())), MODEL, OUT_PSL_GENERIC),
+    (ScatteringProcess((Electron(), Positron()), (Electron(), Positron(), Photon())), MODEL, OUT_PSL_GENERIC),
+    # this is currently producing invalid code on GPUs
+    # See https://github.com/ComputableDAGs/ComputableDAGs.jl/issues/48
+    # or some other workaround
+    #(ScatteringProcess((Electron(), Positron()), (Electron(), Electron(), Positron(), Positron())), MODEL, OUT_PSL_GENERIC),
 ]
 
 RNG = Random.MersenneTwister(573)
@@ -146,13 +150,6 @@ end
                 gt = unsafe_differential_probability.(psps)
                 unsafe_differential_probability!(dest, gpupsps)
                 @test sum(isapprox.(Vector(dest), gt)) == N
-
-                #=
-                fill!(dest, zero(FLOAT_T))
-                gt = differential_probability.(psps)
-                differential_probability!(dest, gpupsps)
-                @test sum(isapprox.(Vector(dest), gt)) == N
-                =#
             end
 
             @testset "KernelAbstractions Cross Section" begin
@@ -161,12 +158,6 @@ end
                 unsafe_differential_cross_section!(dest, gpupsps)
                 @test sum(isapprox.(Vector(dest), gt)) == N
 
-                #=
-                fill!(dest, zero(FLOAT_T))
-                gt = differential_cross_section.(psps)
-                differential_cross_section!(dest, gpupsps)
-                @test sum(isapprox.(Vector(dest), gt)) == N
-                =#
             end
         end
     end

--- a/test/gpu/process_interface.jl
+++ b/test/gpu/process_interface.jl
@@ -63,10 +63,10 @@ end
                 @test eltype(eltype(eltype(in_moms))) == FLOAT_T
                 @test eltype(eltype(eltype(out_moms))) == FLOAT_T
 
-                @test getindex.(in_moms_gpu, Ref(1)) == getindex.(in_moms, Ref(1))
-                @test getindex.(in_moms_gpu, Ref(2)) == getindex.(in_moms, Ref(2))
-                @test getindex.(out_moms_gpu, Ref(1)) == getindex.(out_moms, Ref(1))
-                @test getindex.(out_moms_gpu, Ref(2)) == getindex.(out_moms, Ref(2))
+                @test getindex.(in_moms_gpu, 1) == getindex.(in_moms, 1)
+                @test getindex.(in_moms_gpu, 2) == getindex.(in_moms, 2)
+                @test getindex.(out_moms_gpu, 1) == getindex.(out_moms, 1)
+                @test getindex.(out_moms_gpu, 2) == getindex.(out_moms, 2)
             end
 
             @testset "Private Process Functions" begin

--- a/test/gpu/process_interface.jl
+++ b/test/gpu/process_interface.jl
@@ -189,6 +189,28 @@ end
                     ),
                 ) == N broken = true
             end
+
+            @testset "KernelAbstractions Kernel Interface" begin
+                dest = similar(gpupsps, FLOAT_T)
+                gt = unsafe_differential_cross_section.(psps)
+                unsafe_differential_cross_section!(dest, gpupsps)
+                @test sum(isapprox.(Vector(dest), gt)) == N
+
+                fill!(dest, zero(FLOAT_T))
+                gt = differential_cross_section.(psps)
+                differential_cross_section!(dest, gpupsps)
+                @test sum(isapprox.(Vector(dest), gt)) == N
+
+                fill!(dest, zero(FLOAT_T))
+                gt = unsafe_differential_probability.(psps)
+                unsafe_differential_probability!(dest, gpupsps)
+                @test sum(isapprox.(Vector(dest), gt)) == N
+
+                fill!(dest, zero(FLOAT_T))
+                gt = differential_probability.(psps)
+                differential_probability!(dest, gpupsps)
+                @test sum(isapprox.(Vector(dest), gt)) == N
+            end
         end
     end
 end

--- a/test/gpu/runtests.jl
+++ b/test/gpu/runtests.jl
@@ -100,5 +100,5 @@ end
 include("../test_implementation/random_coordinates.jl")
 
 # from here on, we cannot use safe test sets or we would unload the GPU libraries again
-#include("process_interface.jl")
+include("process_interface.jl")
 include("generic_process.jl")

--- a/test/gpu/runtests.jl
+++ b/test/gpu/runtests.jl
@@ -98,7 +98,6 @@ if metal_tests
 end
 
 include("../test_implementation/random_coordinates.jl")
-include("../utils.jl")
 
 # from here on, we cannot use safe test sets or we would unload the GPU libraries again
 include("process_interface.jl")

--- a/test/gpu/runtests.jl
+++ b/test/gpu/runtests.jl
@@ -100,4 +100,5 @@ end
 include("../test_implementation/random_coordinates.jl")
 
 # from here on, we cannot use safe test sets or we would unload the GPU libraries again
-include("process_interface.jl")
+#include("process_interface.jl")
+include("generic_process.jl")

--- a/test/test_implementation/random_coordinates.jl
+++ b/test/test_implementation/random_coordinates.jl
@@ -16,7 +16,7 @@ function _rand_coordinates(
         rng::AbstractRNG, proc::PROCESS, model::MODEL, psl::PSL, FLOAT_T = Float64
     ) where {PROCESS <: ScatteringProcess, MODEL <: PerturbativeQED, PSL <: AbstractPhaseSpaceLayout}
     return (
-        ntuple(_ -> number_outgoing_particles(proc) + rand(rng, FLOAT_T), QEDbase.phase_space_dimension(proc, model, in_phase_space_layout(psl))),
+        ntuple(_ -> 5 * number_outgoing_particles(proc) + rand(rng, FLOAT_T), QEDbase.phase_space_dimension(proc, model, in_phase_space_layout(psl))),
         ntuple(_ -> rand(rng, FLOAT_T), QEDbase.phase_space_dimension(proc, model, psl)),
     )
 end

--- a/test/test_implementation/random_coordinates.jl
+++ b/test/test_implementation/random_coordinates.jl
@@ -12,6 +12,15 @@ function _rand_coordinates(
     return ((FLOAT_T(0.95) * rand(rng, FLOAT_T) + FLOAT_T(0.05),), (rand(rng, FLOAT_T), rand(rng, FLOAT_T)))
 end
 
+function _rand_coordinates(
+        rng::AbstractRNG, proc::PROCESS, model::MODEL, psl::PSL, FLOAT_T = Float64
+    ) where {PROCESS <: ScatteringProcess, MODEL <: PerturbativeQED, PSL <: AbstractPhaseSpaceLayout}
+    return (
+        ntuple(_ -> number_outgoing_particles(proc) + rand(rng, FLOAT_T), QEDbase.phase_space_dimension(proc, model, in_phase_space_layout(psl))),
+        ntuple(_ -> rand(rng, FLOAT_T), QEDbase.phase_space_dimension(proc, model, psl)),
+    )
+end
+
 tuple_isapprox(v1::SVector, v2::SVector; kwargs...) = tuple_isapprox(Tuple(v1), Tuple(v2); kwargs...)
 tuple_isapprox(::Tuple{}, ::Tuple{Vararg}; atol = 0.0, rtol = eps()) = false
 tuple_isapprox(::Tuple{Vararg}, ::Tuple{}; atol = 0.0, rtol = eps()) = false


### PR DESCRIPTION
This adds the other side of the interface to use the generated kernels from QEDFeynmanDiagrams.jl

It also adds tests for the generic QEDbase.jl KernelAbstractions kernels for the specific 1-photon Compton process, and a new set of tests for `ScatteringProcess`.

The implemented kernels are the unsafe `diff_prob` and `diff_cs` variants.